### PR TITLE
fixed grp_nearby_objs for case when no nearby objs

### DIFF
--- a/peekingduck/pipeline/nodes/heuristic/group_nearby_objs.py
+++ b/peekingduck/pipeline/nodes/heuristic/group_nearby_objs.py
@@ -45,13 +45,12 @@ class Node(AbstractNode):
         nearby_obj_pairs = self._find_nearby_obj_pairs(
             inputs["obj_3D_locs"], self.obj_dist_thres)
 
-        group_alloc = []
         quickfind = QuickFind(len(inputs["obj_3D_locs"]))
         for (idx_1, idx_2) in nearby_obj_pairs:
             if not quickfind.connected(idx_1, idx_2):
-                group_alloc = quickfind.union(idx_1, idx_2)
+                quickfind.union(idx_1, idx_2)
 
-        return {"obj_groups": group_alloc}
+        return {"obj_groups": quickfind.get_group_alloc()}
 
     @staticmethod
     def _find_nearby_obj_pairs(obj_locs: List[np.array],

--- a/peekingduck/pipeline/nodes/heuristic/utils/quick_find.py
+++ b/peekingduck/pipeline/nodes/heuristic/utils/quick_find.py
@@ -32,15 +32,20 @@ class QuickFind:
         for i in range(arr_size):
             self.group_alloc.append(i)
 
-    def union(self, node_1_idx: int, node_2_idx: int) -> List[int]:
+    def get_group_alloc(self) -> List[int]:
+        """Getter function for self.group_alloc
+
+        Returns:
+            (list): a list containing group numbers allocated to each node.
+        """
+        return self.group_alloc
+
+    def union(self, node_1_idx: int, node_2_idx: int) -> None:
         """Unites two nodes and other nodes that have been connected to them.
 
         Args:
             node_1_idx (int): index of the first node
             node_2_idx (int): index of the second node
-
-        Returns:
-            (list): a list containing group numbers allocated to each node
         """
 
         node_1_group = self.group_alloc[node_1_idx]
@@ -48,7 +53,6 @@ class QuickFind:
         for i in range(self.arr_size):
             if self.group_alloc[i] == node_1_group:
                 self.group_alloc[i] = node_2_group
-        return self.group_alloc
 
     def connected(self, node_1_idx: int, node_2_idx: int) -> bool:
         """Checks if two nodes are connected.


### PR DESCRIPTION
1. If 2 objects are nearby, this node should return something like [0, 0] which shows that both are in group 0.
2. If 2 objects are NOT nearby, the node should return [0, 1] as they belong to different groups.

Currently, in the latter case, it returns [] instead which is wrong, as it doesn't get the group_alloc from quick_find due to nearby_obj_pairs being an empty list. 
The fix: created a getter for group_alloc, which will then return group_alloc in both scenarios.