### PR TITLE
Github workflow for publishing to PyPI

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -25,6 +25,7 @@ jobs:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
+    # only pushes to actual PyPI if its a tag (i.e. on release: published)
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master
       with:


### PR DESCRIPTION
Workflow pipeline to push to test PyPI and PyPI. Can be triggered manually or whenever a release is published.

Should consider adding dynamic versioning using `versioneer` 

Closes #97