### PR TITLE
build(dependencies): limited Python versions in setup.cfg to 3.6, 3.7, 3.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.6, !=3.9.*, !=3.10.*
+python_requires = >=3.6, <3.9
 install_requires =
     pyyaml >= 5.3
     click == 7.1.2


### PR DESCRIPTION
Tested on environment with Python 3.9, error occurs as expected:
```
ERROR: Package 'peekingduck' requires a different Python: 3.9.4 not in '!=3.10.*,!=3.9.*,>=3.6'
```

Note: I initially made it `==3.6, ==3.7, ==3.8` but this doesn't work. Seeing as Python releases a new version only once a year, I think the above approach is okay.

closes #485 