### PR TITLE
Fix: change to original directory after running verify install

### DIFF
--- a/peekingduck/cli.py
+++ b/peekingduck/cli.py
@@ -18,6 +18,7 @@ CLI functions for PeekingDuck.
 
 import logging
 import math
+import os
 import tempfile
 from pathlib import Path
 from time import perf_counter
@@ -430,6 +431,7 @@ def _verify_install() -> None:
     """
     LoggerSetup.set_log_level("info")
 
+    cwd = Path.cwd()
     with tempfile.TemporaryDirectory() as tmp_dir:
         pipeline_config_path = Path(tmp_dir) / "verification_pipeline.yml"
 
@@ -456,3 +458,4 @@ def _verify_install() -> None:
             num_iter=None,
         )
         runner.run()
+        os.chdir(cwd)


### PR DESCRIPTION
Fixes `RecursionError` when doing `peekingduck --verify_install` on Windows.