### PR TITLE
Fix: change to previous directory after verify install is done

### DIFF
--- a/peekingduck/commands/core.py
+++ b/peekingduck/commands/core.py
@@ -15,6 +15,7 @@
 """Core PeekingDuck CLI commands."""
 
 import logging
+import os
 import tempfile
 from pathlib import Path
 from time import perf_counter
@@ -132,6 +133,7 @@ def verify_install() -> None:
     """
     LoggerSetup.set_log_level("info")
 
+    cwd = Path.cwd()
     with tempfile.TemporaryDirectory() as tmp_dir:
         pipeline_config_path = Path(tmp_dir) / "verification_pipeline.yml"
 
@@ -156,6 +158,7 @@ def verify_install() -> None:
             num_iter=None,
         )
         runner.run()
+        os.chdir(cwd)
 
 
 def _create_custom_folder(custom_folder_name: str) -> None:


### PR DESCRIPTION
Fixes `RecursionError` when doing `peekingduck --verify_install` on Windows.
