### PR TITLE
Fix: consistent pytest weights location

### DIFF
--- a/tests/pipeline/nodes/base/test_weights_downloader_mixin.py
+++ b/tests/pipeline/nodes/base/test_weights_downloader_mixin.py
@@ -48,7 +48,7 @@ class WeightsModel(WeightsDownloaderMixin):
     def __init__(self, config_file):
         with open(config_file) as infile:
             node_config = yaml.safe_load(infile)
-            node_config["root"] = Path.cwd()
+            node_config["root"] = PKD_DIR
         self.config = node_config
         self.logger = logging.getLogger("test_weights_downloader_mixin.WeightsModel")
 

--- a/tests/pipeline/nodes/dabble/test_camera_calibration.py
+++ b/tests/pipeline/nodes/dabble/test_camera_calibration.py
@@ -86,6 +86,7 @@ def calibration_data(request):
     gc.collect()
 
 
+@pytest.mark.usefixtures("tmp_dir")
 class TestCameraCalibration:
     def test_file_io(self):
         with pytest.raises(ValueError) as excinfo:

--- a/tests/pipeline/nodes/dabble/test_camera_calibration.py
+++ b/tests/pipeline/nodes/dabble/test_camera_calibration.py
@@ -120,10 +120,10 @@ class TestCameraCalibration:
     def test_get_box_info(self):
         for i in range(5):
             start_points, end_points, (text_pos, pos_type) = _get_box_info(i, 1280, 720)
-            assert all(type(val) == int for val in start_points)
-            assert all(type(val) == int for val in end_points)
-            assert all(type(val) == int for val in text_pos)
-            assert type(pos_type) == int
+            assert all(isinstance(val, int) for val in start_points)
+            assert all(isinstance(val, int) for val in end_points)
+            assert all(isinstance(val, int) for val in text_pos)
+            assert isinstance(pos_type, int)
 
     def test_check_initialize_display_scales(self, camera_calibration_node):
         camera_calibration_node._initialize_display_scales(1280)

--- a/tests/pipeline/nodes/model/csrnetv1/test_csrnet.py
+++ b/tests/pipeline/nodes/model/csrnetv1/test_csrnet.py
@@ -28,7 +28,7 @@ GT_RESULTS = get_groundtruth(Path(__file__).resolve())
 def csrnet_config(request):
     with open(PKD_DIR / "configs" / "model" / "csrnet.yml") as infile:
         node_config = yaml.safe_load(infile)
-    node_config["root"] = Path.cwd()
+    node_config["root"] = PKD_DIR
     node_config["model_type"] = request.param
 
     return node_config

--- a/tests/pipeline/nodes/model/efficientdet_d04/test_efficientdet.py
+++ b/tests/pipeline/nodes/model/efficientdet_d04/test_efficientdet.py
@@ -30,7 +30,7 @@ GT_RESULTS = get_groundtruth(Path(__file__).resolve())
 def efficientdet_config():
     with open(PKD_DIR / "configs" / "model" / "efficientdet.yml") as infile:
         node_config = yaml.safe_load(infile)
-    node_config["root"] = Path.cwd()
+    node_config["root"] = PKD_DIR
 
     return node_config
 

--- a/tests/pipeline/nodes/model/fairmotv1/test_fairmot.py
+++ b/tests/pipeline/nodes/model/fairmotv1/test_fairmot.py
@@ -26,7 +26,7 @@ def fairmot_config():
     """Yields config while forcing the model to run on CPU."""
     with open(PKD_DIR / "configs" / "model" / "fairmot.yml") as infile:
         node_config = yaml.safe_load(infile)
-    node_config["root"] = Path.cwd()
+    node_config["root"] = PKD_DIR
 
     with mock.patch("torch.cuda.is_available", return_value=False):
         yield node_config
@@ -39,7 +39,7 @@ def fairmot_config_gpu():
     """
     with open(PKD_DIR / "configs" / "model" / "fairmot.yml") as infile:
         node_config = yaml.safe_load(infile)
-    node_config["root"] = Path.cwd()
+    node_config["root"] = PKD_DIR
 
     yield node_config
 

--- a/tests/pipeline/nodes/model/hrnetv1/test_hrnet.py
+++ b/tests/pipeline/nodes/model/hrnetv1/test_hrnet.py
@@ -31,7 +31,7 @@ GT_RESULTS = get_groundtruth(Path(__file__).resolve())
 def hrnet_config():
     with open(PKD_DIR / "configs" / "model" / "hrnet.yml") as infile:
         node_config = yaml.safe_load(infile)
-    node_config["root"] = Path.cwd()
+    node_config["root"] = PKD_DIR
 
     return node_config
 

--- a/tests/pipeline/nodes/model/jdev1/test_jde.py
+++ b/tests/pipeline/nodes/model/jdev1/test_jde.py
@@ -40,7 +40,7 @@ def jde_config():
     """Yields config while forcing the model to run on CPU."""
     with open(PKD_DIR / "configs" / "model" / "jde.yml") as infile:
         node_config = yaml.safe_load(infile)
-    node_config["root"] = Path.cwd()
+    node_config["root"] = PKD_DIR
 
     with mock.patch("torch.cuda.is_available", return_value=False):
         yield node_config
@@ -53,7 +53,7 @@ def jde_config_gpu():
     """
     with open(PKD_DIR / "configs" / "model" / "jde.yml") as infile:
         node_config = yaml.safe_load(infile)
-    node_config["root"] = Path.cwd()
+    node_config["root"] = PKD_DIR
 
     yield node_config
 

--- a/tests/pipeline/nodes/model/mask_rcnnv1/test_mask_rcnn.py
+++ b/tests/pipeline/nodes/model/mask_rcnnv1/test_mask_rcnn.py
@@ -19,12 +19,12 @@ import cv2
 import numpy as np
 import numpy.testing as npt
 import pytest
-import yaml
 import torch
+import yaml
 
 from peekingduck.pipeline.nodes.base import WeightsDownloaderMixin
-from peekingduck.pipeline.utils.bbox.transforms import xyxy2xyxyn
 from peekingduck.pipeline.nodes.model.mask_rcnn import Node
+from peekingduck.pipeline.utils.bbox.transforms import xyxy2xyxyn
 from tests.conftest import PKD_DIR, get_groundtruth
 
 GT_RESULTS = get_groundtruth(Path(__file__).resolve())
@@ -35,7 +35,7 @@ NP_FILE = np.load(Path(__file__).resolve().parent / "mask_rcnn_gt_masks.npz")
 def mask_rcnn_config():
     with open(PKD_DIR / "configs" / "model" / "mask_rcnn.yml") as infile:
         node_config = yaml.safe_load(infile)
-    node_config["root"] = Path.cwd()
+    node_config["root"] = PKD_DIR
     node_config["iou_threshold"] = 0.5
     node_config["score_threshold"] = 0.5
     node_config["mask_threshold"] = 0.5

--- a/tests/pipeline/nodes/model/mask_rcnnv1/test_mask_rcnn.py
+++ b/tests/pipeline/nodes/model/mask_rcnnv1/test_mask_rcnn.py
@@ -40,7 +40,9 @@ def mask_rcnn_config():
     node_config["score_threshold"] = 0.5
     node_config["mask_threshold"] = 0.5
 
-    return node_config
+    # test on CPU only
+    with mock.patch("torch.cuda.is_available", return_value=False):
+        yield node_config
 
 
 @pytest.fixture(

--- a/tests/pipeline/nodes/model/movenetv1/test_movenet.py
+++ b/tests/pipeline/nodes/model/movenetv1/test_movenet.py
@@ -31,7 +31,7 @@ GT_RESULTS = get_groundtruth(Path(__file__).resolve())
 def movenet_config():
     with open(PKD_DIR / "configs" / "model" / "movenet.yml") as infile:
         node_config = yaml.safe_load(infile)
-    node_config["root"] = Path.cwd()
+    node_config["root"] = PKD_DIR
 
     return node_config
 

--- a/tests/pipeline/nodes/model/movenetv1/test_predictor.py
+++ b/tests/pipeline/nodes/model/movenetv1/test_predictor.py
@@ -36,7 +36,7 @@ def single_person_image(request):
 def movenet_config():
     with open(PKD_DIR / "configs" / "model" / "movenet.yml") as infile:
         node_config = yaml.safe_load(infile)
-    node_config["root"] = Path.cwd()
+    node_config["root"] = PKD_DIR
 
     yield node_config
     K.clear_session()

--- a/tests/pipeline/nodes/model/mtcnnv1/test_mtcnn.py
+++ b/tests/pipeline/nodes/model/mtcnnv1/test_mtcnn.py
@@ -32,7 +32,7 @@ GT_RESULTS = get_groundtruth(Path(__file__).resolve())
 def mtcnn_config():
     with open(PKD_DIR / "configs" / "model" / "mtcnn.yml") as infile:
         node_config = yaml.safe_load(infile)
-    node_config["root"] = Path.cwd()
+    node_config["root"] = PKD_DIR
 
     return node_config
 

--- a/tests/pipeline/nodes/model/posenetv1/test_posenet.py
+++ b/tests/pipeline/nodes/model/posenetv1/test_posenet.py
@@ -33,7 +33,7 @@ GT_RESULTS = get_groundtruth(Path(__file__).resolve())
 def posenet_config():
     with open(PKD_DIR / "configs" / "model" / "posenet.yml") as infile:
         node_config = yaml.safe_load(infile)
-    node_config["root"] = Path.cwd()
+    node_config["root"] = PKD_DIR
     return node_config
 
 

--- a/tests/pipeline/nodes/model/posenetv1/test_predictor.py
+++ b/tests/pipeline/nodes/model/posenetv1/test_predictor.py
@@ -28,7 +28,7 @@ from tests.conftest import PKD_DIR
 def posenet_config():
     with open(PKD_DIR / "configs" / "model" / "posenet.yml") as infile:
         node_config = yaml.safe_load(infile)
-    node_config["root"] = Path.cwd()
+    node_config["root"] = PKD_DIR
     # Only test model_type=75 instead of the default resnet or other types.
     node_config["model_type"] = 75
 

--- a/tests/pipeline/nodes/model/yolact_edgev1/test_yolact_edge.py
+++ b/tests/pipeline/nodes/model/yolact_edgev1/test_yolact_edge.py
@@ -34,7 +34,7 @@ GT_RESULTS = get_groundtruth(Path(__file__).resolve())
 def yolact_edge_config():
     with open(PKD_DIR / "configs" / "model" / "yolact_edge.yml") as infile:
         node_config = yaml.safe_load(infile)
-    node_config["root"] = Path.cwd()
+    node_config["root"] = PKD_DIR
     node_config["score_threshold"] = 0.2
     return node_config
 

--- a/tests/pipeline/nodes/model/yolov4/test_yolo.py
+++ b/tests/pipeline/nodes/model/yolov4/test_yolo.py
@@ -32,7 +32,7 @@ GT_RESULTS = get_groundtruth(Path(__file__).resolve())
 def yolo_config():
     with open(PKD_DIR / "configs" / "model" / "yolo.yml") as infile:
         node_config = yaml.safe_load(infile)
-    node_config["root"] = Path.cwd()
+    node_config["root"] = PKD_DIR
 
     return node_config
 

--- a/tests/pipeline/nodes/model/yolov4_face/test_yolo_face.py
+++ b/tests/pipeline/nodes/model/yolov4_face/test_yolo_face.py
@@ -30,7 +30,7 @@ GT_RESULTS = get_groundtruth(Path(__file__).resolve())
 def yolo_config():
     with open(PKD_DIR / "configs" / "model" / "yolo_face.yml") as infile:
         node_config = yaml.safe_load(infile)
-    node_config["root"] = Path.cwd()
+    node_config["root"] = PKD_DIR
 
     return node_config
 

--- a/tests/pipeline/nodes/model/yolov4_license_plate/test_yolov4_license_plate.py
+++ b/tests/pipeline/nodes/model/yolov4_license_plate/test_yolov4_license_plate.py
@@ -30,7 +30,7 @@ GT_RESULTS = get_groundtruth(Path(__file__).resolve())
 def yolo_config():
     with open(PKD_DIR / "configs" / "model" / "yolo_license_plate.yml") as infile:
         node_config = yaml.safe_load(infile)
-    node_config["root"] = Path.cwd()
+    node_config["root"] = PKD_DIR
 
     return node_config
 

--- a/tests/pipeline/nodes/model/yoloxv1/test_yolox.py
+++ b/tests/pipeline/nodes/model/yoloxv1/test_yolox.py
@@ -33,7 +33,7 @@ GT_RESULTS = get_groundtruth(Path(__file__).resolve())
 def yolox_config():
     with open(PKD_DIR / "configs" / "model" / "yolox.yml") as infile:
         node_config = yaml.safe_load(infile)
-    node_config["root"] = Path.cwd()
+    node_config["root"] = PKD_DIR
 
     return node_config
 


### PR DESCRIPTION
Closes https://github.com/aisingapore/PeekingDuck-Private/issues/87

- Change all `config["root"]` in tests to be initialized as `PKD_DIR`
- Make MaskRCNN tests run on CPU only
- Apply `tmp_dir` fixture to `TestCameraCalibration` to clean up the extra `PeekingDuck/data` folder
- Use `isinstance()` for type checking in `TestCameraCalibration` instead of `type()` [ref](https://switowski.com/blog/type-vs-isinstance)