### PR TITLE
Cicd: output screen test on xvfb

### DIFF
--- a/.github/workflows/daily_drift_checks.yml
+++ b/.github/workflows/daily_drift_checks.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, windows-2019]
+        os: [ubuntu-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/post_merge_checks.yml
+++ b/.github/workflows/post_merge_checks.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest]
+        os: [ubuntu-latest, windows-latest]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/pre_merge_ci.yml
+++ b/.github/workflows/pre_merge_ci.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Run lint checks
         uses: ./.github/actions/linting-checks # note only works after checkout@v2
       - name: Run unit tests
-        run: bash ./scripts/run_tests.sh unit
+        uses: GabrielBB/xvfb-action@v1.6
+        with:
+          run: bash ./scripts/run_tests.sh unit
       - name: Run broken link report
         run: python ./scripts/check_links.py

--- a/.github/workflows/pre_merge_ci.yml
+++ b/.github/workflows/pre_merge_ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-2019]
+        os: [ubuntu-latest, windows-latest]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   local-install-test:
     name: Build PeekingDuck and test locally
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.7
@@ -30,7 +30,7 @@ jobs:
   build-publish-test:
     name: Build PeekingDuck on Test PyPI
     needs: local-install-test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.7
@@ -70,7 +70,7 @@ jobs:
   test-install-pypi:
     name: Build PeekingDuck on PyPI
     needs: build-publish-test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set up Python 3.7
         uses: actions/setup-python@v2

--- a/.github/workflows/standup_bot.yml
+++ b/.github/workflows/standup_bot.yml
@@ -2,20 +2,20 @@ name: Stand-up Bot
 on:
   schedule:
     # runs at 1:30am UTC (09:30am SGT) on Weekdays only
-    - cron: '30 1 * * 1-5'
+    - cron: "30 1 * * 1-5"
 
 jobs:
   build-publish-test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
-    - name: Post to Discord
-      run: |
-        pip install requests pytz
-        bash ./scripts/trigger_standupbot.sh ${{ secrets.DISCORD_WEBHOOK }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Post to Discord
+        run: |
+          pip install requests pytz
+          bash ./scripts/trigger_standupbot.sh ${{ secrets.DISCORD_WEBHOOK }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/peekingduck/declarative_loader.py
+++ b/peekingduck/declarative_loader.py
@@ -20,7 +20,6 @@ import ast
 import collections.abc
 import importlib
 import logging
-
 import os
 import sys
 from pathlib import Path
@@ -63,10 +62,8 @@ class DeclarativeLoader:  # pylint: disable=too-few-public-methods, too-many-ins
         pipeline_path: Path,
         config_updates_cli: str,
         custom_nodes_parent_subdir: str,
-        pkd_viewer: bool = False,
     ) -> None:
         self.logger = logging.getLogger(__name__)
-        self.pkd_viewer = pkd_viewer
 
         self.pkd_base_dir = Path(__file__).resolve().parent
         self.config_loader = ConfigLoader(self.pkd_base_dir)
@@ -211,8 +208,6 @@ class DeclarativeLoader:  # pylint: disable=too-few-public-methods, too-many-ins
                     config, self.config_updates_cli[node_name], node_name
                 )
 
-        # inform node if PeekingDuck Viewer is activated or not
-        config["pkd_viewer"] = self.pkd_viewer
         return node.Node(config)
 
     def _edit_config(

--- a/peekingduck/pipeline/nodes/output/screen.py
+++ b/peekingduck/pipeline/nodes/output/screen.py
@@ -19,17 +19,8 @@ Shows the outputs on your display.
 from typing import Any, Dict, Union
 
 import cv2
-import numpy as np
 
 from peekingduck.pipeline.nodes.abstract_node import AbstractNode
-
-MIN_RENDER_SIZE = 120
-# cv2.getWindowImageRect() returns the size of the display area while
-# cv2.resizeWindow() changes the overall window size.
-# As a result, cv2.getWindowImageRect() will always return a smaller value.
-# Resize the window to be larger than the threshold by an arbitrary factor to
-# avoid having to run cv2.resizeWindow() at every iteration.
-MIN_WINDOW_SIZE = int(MIN_RENDER_SIZE * 1.5)
 
 
 class Node(AbstractNode):
@@ -70,53 +61,25 @@ class Node(AbstractNode):
 
     def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:
         super().__init__(config, node_path=__name__, **kwargs)
-        self.previous_filename = ""
-        pkd_viewer = config["pkd_viewer"] if config is not None else False
-        if not pkd_viewer:
-            cv2.namedWindow(self.window_name, cv2.WINDOW_NORMAL)
-            cv2.moveWindow(self.window_name, self.window_loc["x"], self.window_loc["y"])
+        self.first_run = True
 
     def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Show the outputs on your display"""
         img = inputs["img"]
-        self._set_window_size(inputs["filename"], img)
+        if self.window_size["do_resizing"]:
+            img = cv2.resize(
+                img, (self.window_size["height"], self.window_size["width"])
+            )
+
         cv2.imshow(self.window_name, img)
+        if self.first_run:
+            cv2.moveWindow(self.window_name, self.window_loc["x"], self.window_loc["y"])
+            self.first_run = False
         if cv2.waitKey(1) & 0xFF == ord("q"):
             cv2.destroyWindow(self.window_name)
             return {"pipeline_end": True}
 
         return {"pipeline_end": False}
-
-    def _set_window_size(self, current_filename: str, img: np.ndarray) -> None:
-        """If `do_resizing` option is False, window size will be initialized to the image or
-        video's frame default size for every new video or image.
-
-        If `do_resizing` option is True, window size will be initialized to the config setting's
-        width and height for every new video or image.
-
-        The length of either sides of the display window will be clamped to a lower bound of
-        `MIN_WINDOW_SIZE`
-
-        Args:
-            current_filename (str): The filename from the `inputs` dictionary
-            img (np.ndarray): The current image. The image will not be changed in this function.
-        """
-        if current_filename != self.previous_filename:
-            # Initialize the window size for every new video
-            if self.window_size["do_resizing"]:
-                # Clamp the sides of the window_size to have a minimum of MIN_WINDOW_SIZE
-                img_width = max(self.window_size["width"], MIN_WINDOW_SIZE)
-                img_height = max(self.window_size["height"], MIN_WINDOW_SIZE)
-            else:
-                img_height, img_width, _ = img.shape
-            cv2.resizeWindow(self.window_name, img_width, img_height)
-            self.previous_filename = current_filename
-        else:
-            _, _, win_width, win_height = cv2.getWindowImageRect(self.window_name)
-            if win_width < MIN_RENDER_SIZE or win_height < MIN_RENDER_SIZE:
-                win_width = max(win_width, MIN_WINDOW_SIZE)
-                win_height = max(win_height, MIN_WINDOW_SIZE)
-                cv2.resizeWindow(self.window_name, win_width, win_height)
 
     def _get_config_types(self) -> Dict[str, Any]:
         """Returns dictionary mapping the node's config keys to respective types."""

--- a/peekingduck/viewer/viewer.py
+++ b/peekingduck/viewer/viewer.py
@@ -16,30 +16,29 @@
 Implement PeekingDuck Viewer
 """
 
-from typing import List
-from contextlib import redirect_stderr
-from pathlib import Path
+import copy
 import logging
-from io import StringIO
 import os
 import platform
-import traceback
+import threading
 import tkinter as tk
+import traceback
+from contextlib import redirect_stderr
+from io import StringIO
+from pathlib import Path
 from tkinter import filedialog
 from tkinter.messagebox import askyesno, showerror
-import threading
-import copy
+from typing import List
+
 import cv2
 import numpy as np
 from PIL import Image, ImageTk
+
 from peekingduck.declarative_loader import DeclarativeLoader
 from peekingduck.pipeline.pipeline import Pipeline
 from peekingduck.viewer.playlist import PlayList
 from peekingduck.viewer.viewer_gui import create_window
-from peekingduck.viewer.viewer_utils import (
-    get_keyboard_char,
-    get_keyboard_modifier,
-)
+from peekingduck.viewer.viewer_utils import get_keyboard_char, get_keyboard_modifier
 
 ####################
 # Globals
@@ -601,7 +600,6 @@ class Viewer:  # pylint: disable=too-many-instance-attributes, too-many-public-m
                     self.pipeline_path,
                     self.config_updates_cli,
                     self.custom_nodes_parent_path,
-                    pkd_viewer=True,
                 )
                 self._pipeline: Pipeline = self._node_loader.get_pipeline()
             except Exception:  # pylint: disable=broad-except

--- a/tests/pipeline/nodes/output/test_screen.py
+++ b/tests/pipeline/nodes/output/test_screen.py
@@ -1,0 +1,48 @@
+# Copyright 2022 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import platform
+
+import cv2
+import pytest
+
+from peekingduck.pipeline.nodes.output.screen import Node
+
+
+@pytest.fixture
+def opencv_instance():
+    yield
+    cv2.destroyAllWindows()
+
+
+@pytest.mark.skipif(platform.system() != "Linux", reason="xvfb requires Linux")
+@pytest.mark.usefixtures("opencv_instance")
+class TestScreen:
+    def test_default_screen(self):
+        node = Node()
+        prop = cv2.getWindowProperty(node.window_name, cv2.WND_PROP_VISIBLE)
+        assert int(prop) == 1
+
+    def test_viewer_disables_screen(self):
+        node = Node(
+            {
+                "window_name": "PeekingDuck",
+                "window_size": {"do_resizing": False, "width": 1280, "height": 720},
+                "window_loc": {"x": 0, "y": 0},
+                "pkd_viewer": True,
+            }
+        )
+        with pytest.raises(cv2.error) as excinfo:
+            cv2.getWindowProperty(node.window_name, cv2.WND_PROP_VISIBLE)
+        assert "please create a window" in str(excinfo)

--- a/tests/pipeline/nodes/output/test_screen.py
+++ b/tests/pipeline/nodes/output/test_screen.py
@@ -27,7 +27,6 @@ from tests.conftest import PKD_DIR
 def screen_config():
     with open(PKD_DIR / "configs" / "output" / "screen.yml") as infile:
         node_config = yaml.safe_load(infile)
-    node_config["pkd_viewer"] = False
 
     return node_config
 

--- a/tests/pipeline/nodes/output/test_screen.py
+++ b/tests/pipeline/nodes/output/test_screen.py
@@ -13,11 +13,23 @@
 # limitations under the License.
 
 import platform
+from unittest import mock
 
 import cv2
 import pytest
+import yaml
 
-from peekingduck.pipeline.nodes.output.screen import Node
+from peekingduck.pipeline.nodes.output.screen import MIN_DISPLAY_SIZE, Node
+from tests.conftest import PKD_DIR
+
+
+@pytest.fixture
+def screen_config():
+    with open(PKD_DIR / "configs" / "output" / "screen.yml") as infile:
+        node_config = yaml.safe_load(infile)
+    node_config["pkd_viewer"] = False
+
+    return node_config
 
 
 @pytest.fixture
@@ -34,15 +46,57 @@ class TestScreen:
         prop = cv2.getWindowProperty(node.window_name, cv2.WND_PROP_VISIBLE)
         assert int(prop) == 1
 
-    def test_viewer_disables_screen(self):
-        node = Node(
-            {
-                "window_name": "PeekingDuck",
-                "window_size": {"do_resizing": False, "width": 1280, "height": 720},
-                "window_loc": {"x": 0, "y": 0},
-                "pkd_viewer": True,
-            }
-        )
+    def test_viewer_disables_screen(self, screen_config):
+        screen_config["pkd_viewer"] = True
+        node = Node(screen_config)
         with pytest.raises(cv2.error) as excinfo:
             cv2.getWindowProperty(node.window_name, cv2.WND_PROP_VISIBLE)
         assert "please create a window" in str(excinfo)
+
+    def test_resize_to_image(self, create_input_image):
+        node = Node()
+        filename = "image1.png"
+        width = 800
+        height = 900
+        image = create_input_image(filename, (height, width, 3))
+        inputs = {"filename": filename, "img": image}
+        with mock.patch("cv2.resizeWindow") as mock_resize:
+            node.run(inputs)
+
+        assert mock_resize.call_args == ((node.window_name, width, height),)
+
+    def test_resize_to_config(self, screen_config, create_input_image):
+        width = 800
+        height = 900
+        screen_config["window_size"] = {
+            "do_resizing": True,
+            "height": height,
+            "width": width,
+        }
+        node = Node(screen_config)
+        filename = "image1.png"
+        image = create_input_image(filename, (height // 2, width // 2, 3))
+        inputs = {"filename": filename, "img": image}
+        with mock.patch("cv2.resizeWindow") as mock_resize:
+            node.run(inputs)
+
+        assert mock_resize.call_args == ((node.window_name, width, height),)
+
+    def test_resize_to_min_size(self, screen_config, create_input_image):
+        width = MIN_DISPLAY_SIZE // 2
+        height = MIN_DISPLAY_SIZE // 2
+        screen_config["window_size"] = {
+            "do_resizing": True,
+            "height": height,
+            "width": width,
+        }
+        node = Node(screen_config)
+        filename = "image1.png"
+        image = create_input_image(filename, (height // 2, width // 2, 3))
+        inputs = {"filename": filename, "img": image}
+        with mock.patch("cv2.resizeWindow") as mock_resize:
+            node.run(inputs)
+
+        assert mock_resize.call_args == (
+            (node.window_name, MIN_DISPLAY_SIZE, MIN_DISPLAY_SIZE),
+        )


### PR DESCRIPTION
Addresses https://github.com/aisingapore/PeekingDuck/issues/433

- Uses https://github.com/marketplace/actions/gabrielbb-xvfb-action to run `output.screen`tests in a headless environment
  - `output.screen` tests are only run if the platform is Linux because xvfb does not work on other platforms.
- Refactored `output/screen.py` to have 2 constants `MIN_RENDER_SIZE` and `MIN_WINDOW_SIZE` as a workaround to OpenCV quirk
  - The scale factor of 1.5 is arbitrary and can be updated if a larger value is required on other platforms/OSes
- Update GitHub runners to use `ubuntu-latest` and `windows-latest`