### PR TITLE
Cicd: run post merge with xvfb

### DIFF
--- a/.github/workflows/post_merge_checks.yml
+++ b/.github/workflows/post_merge_checks.yml
@@ -38,6 +38,8 @@ jobs:
           pip install . --no-dependencies
         shell: bash
       - name: Run all tests
-        run: bash ./scripts/run_tests.sh post_merge
+        uses: GabrielBB/xvfb-action@v1.6
+        with:
+          run: bash ./scripts/run_tests.sh post_merge
       - name: Run broken link report
         run: python ./scripts/check_links.py

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -19,14 +19,18 @@ jobs:
       - name: Update Version Number
         run: |
           bash ./scripts/update_version.sh $VERSION
-      - name: Local Test
+      - name: Local Install
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r cicd_requirements.txt
           pip install .
-          bash ./scripts/run_tests.sh all
-          bash ./scripts/usecase_tests.sh
+      - name: Local Test
+        uses: GabrielBB/xvfb-action@v1.6
+        with:
+          run: |
+            bash ./scripts/run_tests.sh all
+            bash ./scripts/usecase_tests.sh
   build-publish-test:
     name: Build PeekingDuck on Test PyPI
     needs: local-install-test


### PR DESCRIPTION
Use `xvfb` action to run post-merge tests in `post_merge_checks.yml` and local tests in `publish_pypi.yml`