### PR TITLE
Refactor: consistent output types

### DIFF
--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/detector.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/detector.py
@@ -108,14 +108,15 @@ class Detector:  # pylint: disable=too-few-public-methods,too-many-instance-attr
         self,
         network_output: Tuple[np.ndarray, np.ndarray, np.ndarray],
         scale: float,
-        img_shape: Tuple[int, int],
+        img_shape: Tuple[int, ...],
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Postprocessing of detected bboxes for efficientdet
 
         Args:
-            network_output (list): list of boxes, scores and labels from network
-            scale (float): scale the image was resized to
-            img_shape (Tuple[int, int]): height of original image
+            network_output (Tuple[np.ndarray, np.ndarray, np.ndarray]): Tuple of
+                boxes, scores and labels from the network.
+            scale (float): Scale to which the image was resized.
+            img_shape (Tuple[int, ...]): height of original image
 
         Returns:
             boxes (np.ndarray): postprocessed array of detected bboxes
@@ -138,7 +139,7 @@ class Detector:  # pylint: disable=too-few-public-methods,too-many-instance-attr
         labels = labels[detect_filter]
         scores = scores[detect_filter]
 
-        if labels.size:
+        if labels.size > 0:
             labels = np.vectorize(self.class_names.get)(labels)
         return boxes, labels, scores
 

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/detector.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/detector.py
@@ -71,7 +71,7 @@ class Detector:  # pylint: disable=too-few-public-methods,too-many-instance-attr
             labels (np.ndarray): array of labels
             scores (np.ndarray): array of scores
         """
-        img_shape = image.shape[:2]
+        img_shape = image.shape[0], image.shape[1]
         image, scale = self._preprocess(image)
 
         # run network
@@ -108,7 +108,7 @@ class Detector:  # pylint: disable=too-few-public-methods,too-many-instance-attr
         self,
         network_output: Tuple[np.ndarray, np.ndarray, np.ndarray],
         scale: float,
-        img_shape: Tuple[int, ...],
+        img_shape: Tuple[int, int],
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Postprocessing of detected bboxes for efficientdet
 
@@ -116,7 +116,7 @@ class Detector:  # pylint: disable=too-few-public-methods,too-many-instance-attr
             network_output (Tuple[np.ndarray, np.ndarray, np.ndarray]): Tuple of
                 boxes, scores and labels from the network.
             scale (float): Scale to which the image was resized.
-            img_shape (Tuple[int, ...]): height of original image
+            img_shape (Tuple[int, int]): Height and width of original image
 
         Returns:
             boxes (np.ndarray): postprocessed array of detected bboxes

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/model_process.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/model_process.py
@@ -19,7 +19,7 @@
 Processing helper functions for EfficientDet
 """
 
-from typing import List, Tuple
+from typing import Tuple
 
 import cv2
 import numpy as np
@@ -28,17 +28,15 @@ IMG_MEAN = [0.485, 0.456, 0.406]
 IMG_STD = [0.229, 0.224, 0.225]
 
 
-def preprocess_image(
-    image: np.ndarray, image_size: int
-) -> Tuple[List[List[float]], float]:
+def preprocess_image(image: np.ndarray, image_size: int) -> Tuple[np.ndarray, float]:
     """Preprocessing helper function for efficientdet
 
     Args:
-        image (np.array): the input image in numpy array
+        image (np.ndarray): the input image in numpy array
         image_size (int): the model input size as specified in config
 
     Returns:
-        image (np.array): the preprocessed image
+        image (np.ndarray): the preprocessed image
         scale (float): the scale in which the original image was resized to
     """
     # image, RGB
@@ -70,13 +68,13 @@ def postprocess_boxes(
     """Postprocessing helper function for efficientdet
 
     Args:
-        boxes (np.array): the original detected bboxes from model output
+        boxes (np.ndarray): the original detected bboxes from model output
         scale (float): scale in which the original image was resized to
         height (int): the height of the original image
         width (int): the width of the original image
 
     Returns:
-        boxes (np.array): the postprocessed bboxes
+        boxes (np.ndarray): the postprocessed bboxes
     """
     boxes /= scale
     boxes[:, 0] = np.clip(boxes[:, 0], 0, width - 1)

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_model.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_model.py
@@ -80,14 +80,11 @@ class EfficientDetModel(ThresholdCheckerMixin, WeightsDownloaderMixin):
             image (np.ndarray): Input image frame.
 
         Returns:
-            object_bboxes(List[Numpy ndarray]): list of bboxes detected
-            object_labels(List[str]): list of index labels of the
-                object detected for the corresponding bbox
-            object_scores(List[float]): list of confidence scores of the
-                object detected for the corresponding bbox
+            bboxes (np.ndarray): Array of bboxes for the detected objects.
+            labels (np.ndarray): Array of class labels of the detected objects.
+            scores (np.ndarray): Array of confidence scores of the detected objects.
         """
         if not isinstance(image, np.ndarray):
             raise TypeError("image must be a np.ndarray")
 
-        # returns object_bboxes, object_labels, object_scores
         return self.detector.predict_object_bbox_from_image(image)

--- a/peekingduck/pipeline/nodes/model/fairmot.py
+++ b/peekingduck/pipeline/nodes/model/fairmot.py
@@ -93,10 +93,10 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
 
         Returns:
             (Dict[str, Any]): Dictionary containing:
-            - bboxes (List[np.ndarray]): Bounding boxes for tracked targets.
+            - bboxes (np.ndarray): Bounding boxes for tracked targets.
             - bbox_labels (np.ndarray): Bounding box labels, hard coded as
                 "person".
-            - bbox_scores (List[float]): Detection confidence scores.
+            - bbox_scores (np.ndarray): Detection confidence scores.
             - obj_attrs (Dict[str, List[int]]): Tracking IDs, specifically for use
                 with `mot_evaluator`.
         """

--- a/peekingduck/pipeline/nodes/model/fairmotv1/fairmot_files/tracker.py
+++ b/peekingduck/pipeline/nodes/model/fairmotv1/fairmot_files/tracker.py
@@ -365,7 +365,7 @@ class Tracker:  # pylint: disable=too-many-instance-attributes
         self.logger.info(
             "FairMOT model loaded with the following config:\n\t"
             f"Model type: {self.model_type}\n\t"
-            f"Input resolution: {self.input_size}"
+            f"Input resolution: {self.input_size}\n\t"
             f"Score threshold: {self.score_threshold}\n\t"
             f"Max number of output objects: {self.max_per_image}\n\t"
             f"Min bounding box area: {self.min_box_area}\n\t"

--- a/peekingduck/pipeline/nodes/model/fairmotv1/fairmot_files/tracker.py
+++ b/peekingduck/pipeline/nodes/model/fairmotv1/fairmot_files/tracker.py
@@ -153,14 +153,14 @@ class Tracker:  # pylint: disable=too-many-instance-attributes
 
     def track_objects_from_image(
         self, image: np.ndarray
-    ) -> Tuple[List[np.ndarray], List[int], List[float]]:
+    ) -> Tuple[np.ndarray, List[int], np.ndarray]:
         """Tracks detections from the current video frame.
 
         Args:
             image (np.ndarray): The current video frame.
 
         Returns:
-            (Tuple[List[np.ndarray], List[str], List[float]]): A tuple of
+            (Tuple[np.ndarray, List[int], np.ndarray]): A tuple of
             - Numpy array of detected bounding boxes.
             - List of track IDs.
             - List of detection confidence scores.
@@ -182,11 +182,11 @@ class Tracker:  # pylint: disable=too-many-instance-attributes
                 online_ids.append(target.track_id)
                 scores.append(target.score.item())
         if not online_tlwhs:
-            return online_tlwhs, online_ids, scores
+            return np.empty((0, 4)), online_ids, np.empty(0)
 
-        bboxes = self._postprocess(np.asarray(online_tlwhs), image_size)
+        bboxes = self._postprocess(np.array(online_tlwhs), image_size)
 
-        return bboxes, online_ids, scores
+        return bboxes, online_ids, np.array(scores)
 
     def update(  # pylint: disable=too-many-branches,too-many-locals,too-many-statements
         self, pred_detections: torch.Tensor, pred_embeddings: torch.Tensor

--- a/peekingduck/pipeline/nodes/model/fairmotv1/fairmot_model.py
+++ b/peekingduck/pipeline/nodes/model/fairmotv1/fairmot_model.py
@@ -79,16 +79,14 @@ class FairMOTModel(ThresholdCheckerMixin, WeightsDownloaderMixin):
             self.config["score_threshold"],
         )
 
-    def predict(
-        self, image: np.ndarray
-    ) -> Tuple[List[np.ndarray], List[float], List[int]]:
+    def predict(self, image: np.ndarray) -> Tuple[np.ndarray, np.ndarray, List[int]]:
         """Track objects from image.
 
         Args:
             image (np.ndarray): Image in numpy array.
 
         Returns:
-            (Tuple[List[np.ndarray], List[str], List[float], List[int]]): A tuple of
+            (Tuple[np.ndarray, np.ndarray, List[int]]): A tuple of
             - Numpy array of detected bounding boxes.
             - List of detection confidence scores.
             - List of track IDs.

--- a/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_model.py
+++ b/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_model.py
@@ -61,10 +61,7 @@ class HRNetModel(ThresholdCheckerMixin, WeightsDownloaderMixin):
         assert isinstance(frame, np.ndarray)
         assert isinstance(bboxes, np.ndarray)
         detected_bboxes = bboxes.copy()
-        if bboxes.size != 0:
-            return self.detector.predict(frame, detected_bboxes)
-        keypoints = np.array([])
-        keypoint_scores = np.array([])
-        keypoint_conns = np.array([])
+        if bboxes.size == 0:
+            return np.empty(0), np.empty(0), np.empty(0)
 
-        return keypoints, keypoint_scores, keypoint_conns
+        return self.detector.predict(frame, detected_bboxes)

--- a/peekingduck/pipeline/nodes/model/jde.py
+++ b/peekingduck/pipeline/nodes/model/jde.py
@@ -88,10 +88,10 @@ class Node(AbstractNode):
 
         Returns:
             outputs (dict): Dictionary containing:
-            - bboxes (List[np.ndarray]): Bounding boxes for tracked targets.
+            - bboxes (np.ndarray): Bounding boxes for tracked targets.
             - bbox_labels (np.ndarray): Bounding box labels, hard coded as
                 "person".
-            - bbox_scores (List[float]): Detection confidence scores.
+            - bbox_scores (np.ndarray): Detection confidence scores.
             - obj_attrs (Dict[str, List[int]]): Tracking IDs, specifically for use
                 with `mot_evaluator`.
         """

--- a/peekingduck/pipeline/nodes/model/jde.py
+++ b/peekingduck/pipeline/nodes/model/jde.py
@@ -69,7 +69,7 @@ class Node(AbstractNode):
         https://github.com/Zhongdao/Towards-Realtime-MOT
     """
 
-    def __init__(self, config: Dict[str, Any], **kwargs: Any) -> None:
+    def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:
         super().__init__(config, node_path=__name__, **kwargs)
         self._frame_rate = 30.0
 

--- a/peekingduck/pipeline/nodes/model/jdev1/jde_files/tracker.py
+++ b/peekingduck/pipeline/nodes/model/jdev1/jde_files/tracker.py
@@ -114,14 +114,14 @@ class Tracker:  # pylint: disable=too-many-instance-attributes
 
     def track_objects_from_image(
         self, image: np.ndarray
-    ) -> Tuple[List[np.ndarray], List[int], List[float]]:
+    ) -> Tuple[np.ndarray, List[int], np.ndarray]:
         """Tracks detections from the current video frame.
 
         Args:
             image (np.ndarray): The current video frame.
 
         Returns:
-            (Tuple[List[np.ndarray], List[int], List[float]]): A tuple of
+            (Tuple[np.ndarray, List[int], np.ndarray]): A tuple of
             - Numpy array of detected bounding boxes.
             - List of track IDs.
             - List of detection confidence scores.
@@ -142,11 +142,11 @@ class Tracker:  # pylint: disable=too-many-instance-attributes
                 online_ids.append(target.track_id)
                 scores.append(target.score.item())
         if not online_tlwhs:
-            return online_tlwhs, online_ids, scores
+            return np.empty((0, 4)), online_ids, np.empty(0)
 
-        bboxes = self._postprocess(np.asarray(online_tlwhs), image_size)
+        bboxes = self._postprocess(np.array(online_tlwhs), image_size)
 
-        return bboxes, online_ids, scores
+        return bboxes, online_ids, np.array(scores)
 
     @torch.no_grad()
     def update(  # pylint: disable=too-many-branches,too-many-locals,too-many-statements

--- a/peekingduck/pipeline/nodes/model/jdev1/jde_model.py
+++ b/peekingduck/pipeline/nodes/model/jdev1/jde_model.py
@@ -82,9 +82,7 @@ class JDEModel(ThresholdCheckerMixin, WeightsDownloaderMixin):
             self.config["score_threshold"],
         )
 
-    def predict(
-        self, image: np.ndarray
-    ) -> Tuple[List[np.ndarray], List[float], List[int]]:
+    def predict(self, image: np.ndarray) -> Tuple[np.ndarray, np.ndarray, List[int]]:
         """Track objects from image.
 
         Args:

--- a/peekingduck/pipeline/nodes/model/movenetv1/movenet_files/predictor.py
+++ b/peekingduck/pipeline/nodes/model/movenetv1/movenet_files/predictor.py
@@ -161,8 +161,8 @@ class Predictor:  # pylint: disable=too-many-instance-attributes
         bbox_masks = self._get_masks_from_bbox_scores(
             bbox_score, self.bbox_score_threshold
         )
-        if len(bbox_masks) == 0:
-            return (np.zeros(0), np.zeros(0), np.zeros(0), np.zeros(0))
+        if not bbox_masks:
+            return np.empty((0, 4)), np.empty(0), np.empty(0), np.empty(0)
 
         bboxes = bboxes[bbox_masks, :]
         bbox_score = bbox_score[bbox_masks]
@@ -219,8 +219,8 @@ class Predictor:  # pylint: disable=too-many-instance-attributes
         #     return (np.zeros(0), np.zeros(0), np.zeros(0), np.zeros(0))
         # if all the keypoints_score are below threshold, valid_keypoints
         # will be an array with all [-1,-1]
-        if np.all(valid_keypoints == np.asarray([[-1, -1]])):
-            return (np.zeros(0), np.zeros(0), np.zeros(0), np.zeros(0))
+        if np.all(valid_keypoints == np.array([[-1, -1]])):
+            return np.empty((0, 4)), np.empty(0), np.empty(0), np.empty(0)
 
         keypoints_conns = self._get_connections_of_poses(keypoints, keypoints_masks)
         bbox = self._get_bbox_from_keypoints(valid_keypoints)

--- a/peekingduck/pipeline/nodes/model/mtcnnv1/mtcnn_files/detector.py
+++ b/peekingduck/pipeline/nodes/model/mtcnnv1/mtcnn_files/detector.py
@@ -20,6 +20,7 @@ from typing import Callable, Dict, List, Tuple
 
 import numpy as np
 import tensorflow as tf
+
 from peekingduck.pipeline.nodes.model.mtcnnv1.mtcnn_files.graph_functions import (
     load_graph,
 )
@@ -142,7 +143,7 @@ class Detector:  # pylint: disable=too-few-public-methods,too-many-instance-attr
             image (np.ndarray): image in numpy array
 
         Returns:
-            image (np.ndarray): processed numpy array of image
+            image (tf.Tensor): processed image
         """
         image = image.astype(np.float32)
         image = tf.convert_to_tensor(image)

--- a/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/predictor.py
+++ b/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/predictor.py
@@ -107,6 +107,13 @@ class Predictor:  # pylint: disable=too-many-instance-attributes
             keypoint_scores.append(pose_scores)
             keypoint_conns.append(pose_connections)
 
+        if not bboxes:
+            return (
+                np.empty((0, 4)),
+                np.array(keypoints),
+                np.array(keypoint_scores),
+                np.array(keypoint_conns),
+            )
         return (
             np.array(bboxes),
             np.array(keypoints),

--- a/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/predictor.py
+++ b/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/predictor.py
@@ -108,12 +108,7 @@ class Predictor:  # pylint: disable=too-many-instance-attributes
             keypoint_conns.append(pose_connections)
 
         if not bboxes:
-            return (
-                np.empty((0, 4)),
-                np.array(keypoints),
-                np.array(keypoint_scores),
-                np.array(keypoint_conns),
-            )
+            return np.empty((0, 4)), np.empty(0), np.empty(0), np.empty(0)
         return (
             np.array(bboxes),
             np.array(keypoints),

--- a/peekingduck/pipeline/nodes/model/posenetv1/posenet_model.py
+++ b/peekingduck/pipeline/nodes/model/posenetv1/posenet_model.py
@@ -54,15 +54,15 @@ class PoseNetModel(ThresholdCheckerMixin, WeightsDownloaderMixin):
     def predict(
         self, frame: np.ndarray
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-        """ Predict poses from input frame
+        """Predict poses from input frame
 
         Args:
             frame (np.array): image in numpy array
 
         Returns:
             bboxes, keypoints, keypoint_scores, keypoint_masks, keypoint_conns
-            (Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]): \
-            tuple containing list of bboxes and pose related info i.e coordinates,
+            (Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]): tuple
+            containing list of bboxes and pose related info i.e coordinates,
             scores, connections
         """
         assert isinstance(frame, np.ndarray)

--- a/peekingduck/pipeline/nodes/model/yolact_edgev1/yolact_edge_files/detector.py
+++ b/peekingduck/pipeline/nodes/model/yolact_edgev1/yolact_edge_files/detector.py
@@ -20,12 +20,11 @@ import logging
 from pathlib import Path
 from typing import Dict, List, Tuple
 
-import torch.backends as cudnn
-from torch import Tensor
-import torch.nn.functional as F
-import torch
-
 import numpy as np
+import torch
+import torch.backends as cudnn
+import torch.nn.functional as F
+from torch import Tensor
 
 from peekingduck.pipeline.nodes.model.yolact_edgev1.yolact_edge_files.model import (
     YolactEdge,
@@ -239,16 +238,7 @@ class Detector:  # pylint: disable=too-many-instance-attributes
             boxes = np.clip(boxes, 0, 1)
             scores = np.array(score[detect_filter].cpu())
             masks = np.array(mask[detect_filter].cpu()).astype(np.uint8)
-
-        except TypeError:
-            return (
-                np.empty((0)),
-                np.empty((0), dtype=np.float32),
-                np.empty((0, 4), dtype=np.float32),
-                np.empty((0, 0, 0), dtype=np.uint8),
-            )
-
-        except RuntimeError:
+        except (RuntimeError, TypeError):
             return (
                 np.empty((0)),
                 np.empty((0), dtype=np.float32),

--- a/peekingduck/pipeline/nodes/model/yolov4/yolo_files/detector.py
+++ b/peekingduck/pipeline/nodes/model/yolov4/yolo_files/detector.py
@@ -16,7 +16,6 @@
 Object detection class using yolo model to find object bboxes
 """
 
-
 import logging
 from pathlib import Path
 from typing import Callable, Dict, List, Tuple
@@ -69,9 +68,11 @@ class Detector:  # pylint: disable=too-few-public-methods,too-many-instance-attr
             image (np.ndarray): input image
 
         Return:
-            boxes (np.array): an array of bounding box with definition like
+            boxes (np.ndarray): an array of bounding box with definition like
                 (x1, y1, x2, y2), in a coordinate system with original point in
                 the top-left corner
+            labels (np.ndarray): array of labels
+            scores (np.ndarray): array of scores
         """
         image = self._preprocess(image)
 

--- a/tests/pipeline/nodes/model/fairmotv1/__init__.py
+++ b/tests/pipeline/nodes/model/fairmotv1/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/pipeline/nodes/model/fairmotv1/test_fairmot.py
+++ b/tests/pipeline/nodes/model/fairmotv1/test_fairmot.py
@@ -1,3 +1,17 @@
+# Copyright 2022 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from pathlib import Path
 from unittest import TestCase, mock
 

--- a/tests/pipeline/nodes/model/fairmotv1/test_fairmot.py
+++ b/tests/pipeline/nodes/model/fairmotv1/test_fairmot.py
@@ -98,9 +98,9 @@ class TestFairMOT:
         fairmot = Node(fairmot_config)
         output = fairmot.run({"img": no_human_img})
         expected_output = {
-            "bboxes": [],
-            "bbox_labels": [],
-            "bbox_scores": [],
+            "bboxes": np.empty((0, 4)),
+            "bbox_labels": np.empty(0),
+            "bbox_scores": np.empty(0),
             "obj_attrs": {"ids": []},
         }
         assert output.keys() == expected_output.keys()

--- a/tests/pipeline/nodes/model/fairmotv1/test_tracker.py
+++ b/tests/pipeline/nodes/model/fairmotv1/test_tracker.py
@@ -1,3 +1,17 @@
+# Copyright 2022 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import numpy as np
 import torch
 

--- a/tests/pipeline/nodes/model/jdev1/test_jde.py
+++ b/tests/pipeline/nodes/model/jdev1/test_jde.py
@@ -97,9 +97,9 @@ class TestJDE:
         jde = Node(jde_config)
         output = jde.run({"img": no_human_img})
         expected_output = {
-            "bboxes": [],
-            "bbox_labels": [],
-            "bbox_scores": [],
+            "bboxes": np.empty((0, 4)),
+            "bbox_labels": np.empty(0),
+            "bbox_scores": np.empty(0),
             "obj_attrs": {"ids": []},
         }
         assert output.keys() == expected_output.keys()

--- a/tests/pipeline/nodes/model/movenetv1/test_movenet.py
+++ b/tests/pipeline/nodes/model/movenetv1/test_movenet.py
@@ -71,20 +71,16 @@ class TestMoveNet:
         model = Node(movenet_config_single)
         output = model.run({"img": no_human_img})
         expected_output = {
-            "bboxes": np.zeros(0),
-            "keypoints": np.zeros(0),
-            "keypoint_scores": np.zeros(0),
-            "keypoint_conns": np.zeros(0),
-            "bbox_labels": np.zeros(0),
+            "bboxes": np.empty((0, 4)),
+            "keypoints": np.empty(0),
+            "keypoint_scores": np.empty(0),
+            "keypoint_conns": np.empty(0),
+            "bbox_labels": np.empty(0),
         }
         assert output.keys() == expected_output.keys()
         for i in expected_output.keys():
             npt.assert_array_equal(
-                x=output[i],
-                y=expected_output[i],
-                err_msg=(
-                    f"unexpected output for {i}, Expected {np.zeros(0)} got {output[i]}"
-                ),
+                output[i], expected_output[i], f"unexpected output for `{i}`"
             )
 
     def test_no_human_multi(self, no_human_image, movenet_config_multi):
@@ -92,20 +88,16 @@ class TestMoveNet:
         model = Node(movenet_config_multi)
         output = model.run({"img": no_human_img})
         expected_output = {
-            "bboxes": np.zeros(0),
-            "keypoints": np.zeros(0),
-            "keypoint_scores": np.zeros(0),
-            "keypoint_conns": np.zeros(0),
-            "bbox_labels": np.zeros(0),
+            "bboxes": np.empty((0, 4)),
+            "keypoints": np.empty(0),
+            "keypoint_scores": np.empty(0),
+            "keypoint_conns": np.empty(0),
+            "bbox_labels": np.empty(0),
         }
         assert output.keys() == expected_output.keys()
         for i in expected_output.keys():
             npt.assert_array_equal(
-                x=output[i],
-                y=expected_output[i],
-                err_msg=(
-                    f"unexpected output for {i}, Expected {np.zeros(0)} got {output[i]}"
-                ),
+                output[i], expected_output[i], f"unexpected output for `{i}`"
             )
 
     def test_single_person(self, single_person_image, movenet_config_single):
@@ -149,9 +141,7 @@ class TestMoveNet:
         # Thus, iterate through the detections
         for i, expected_keypoint_conns in enumerate(expected["keypoint_conns"]):
             npt.assert_allclose(
-                output["keypoint_conns"][i],
-                expected_keypoint_conns,
-                atol=TOLERANCE,
+                output["keypoint_conns"][i], expected_keypoint_conns, atol=TOLERANCE
             )
 
         npt.assert_allclose(

--- a/tests/pipeline/nodes/model/movenetv1/test_predictor.py
+++ b/tests/pipeline/nodes/model/movenetv1/test_predictor.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import gc
-from pathlib import Path
 
 import cv2
 import numpy as np
@@ -55,7 +54,7 @@ def model_dir(movenet_config):
 
 @pytest.mark.mlmodel
 class TestPredictor:
-    def test_predictor(self, movenet_config, model_dir):
+    def test_predictor_init(self, movenet_config, model_dir):
         movenet_predictor = Predictor(
             model_dir,
             movenet_config["model_format"],
@@ -66,21 +65,11 @@ class TestPredictor:
             movenet_config["keypoint_score_threshold"],
         )
         assert movenet_predictor is not None, "Predictor is not instantiated"
-
-    def test_model_creation(self, movenet_config, model_dir):
-        movenet_predictor = Predictor(
-            model_dir,
-            movenet_config["model_format"],
-            movenet_config["model_type"],
-            movenet_config["weights"][movenet_config["model_format"]]["model_file"],
-            movenet_config["resolution"],
-            movenet_config["bbox_score_threshold"],
-            movenet_config["keypoint_score_threshold"],
-        )
         assert movenet_predictor.model is not None, "Model is not loaded"
 
     def test_get_resolution_as_tuple(self, movenet_config, model_dir):
-        resolution = {"height": 256, "width": 256}
+        expected_res = (256, 256)
+        resolution = {"height": expected_res[0], "width": expected_res[1]}
         movenet_predictor = Predictor(
             model_dir,
             movenet_config["model_format"],
@@ -91,16 +80,8 @@ class TestPredictor:
             movenet_config["keypoint_score_threshold"],
         )
         tuple_res = movenet_predictor.get_resolution_as_tuple(resolution)
-        assert isinstance(
-            tuple_res, tuple
-        ), f"Resolution in config must be a tuple instead of {type(tuple_res)}"
-        assert tuple_res == (
-            256,
-            256,
-        ), f"Incorrect resolution: expected (256, 256) but got {tuple_res}"
-        assert (
-            len(tuple_res) == 2
-        ), f"Wrong resolution dimension: expected 2 but got {len(tuple_res)}"
+        assert isinstance(tuple_res, tuple), f"Expected tuple, got {type(tuple_res)}"
+        assert tuple_res == expected_res, f"Expected {expected_res}, got {tuple_res}"
 
     def test_predict(self, movenet_config, model_dir, single_person_image):
         img = cv2.imread(str(TEST_IMAGES_DIR / single_person_image))
@@ -162,38 +143,10 @@ class TestPredictor:
             keypoints_scores_no_pose,
             keypoints_conns_no_pose,
         ) = movenet_predictor._get_results_single(prediction_no_pose)
-        npt.assert_array_equal(
-            x=bbox_no_pose,
-            y=np.zeros(0),
-            err_msg=(
-                "Unexpected bbox output for prediction with keypoint score below "
-                f"threshold got {bbox_no_pose} instead of {np.zeros(0)}"
-            ),
-        )
-        npt.assert_array_equal(
-            x=valid_keypoints_no_pose,
-            y=np.zeros(0),
-            err_msg=(
-                "Unexpected valid keypoint output for prediction with keypoint score "
-                f"below threshold got {valid_keypoints_no_pose} instead of {np.zeros(0)}"
-            ),
-        )
-        npt.assert_array_equal(
-            x=keypoints_scores_no_pose,
-            y=np.zeros(0),
-            err_msg=(
-                "Unexpected keypoint score output for prediction with keypoint score "
-                f"below threshold got {keypoints_scores_no_pose} instead of {np.zeros(0)}"
-            ),
-        )
-        npt.assert_array_equal(
-            x=keypoints_conns_no_pose,
-            y=np.zeros(0),
-            err_msg=(
-                "Unexpected keypoint connection output for prediction with keypoint "
-                f"score below threshold got {keypoints_conns_no_pose} instead of {np.zeros(0)}"
-            ),
-        )
+        npt.assert_array_equal(bbox_no_pose, np.empty((0, 4)))
+        npt.assert_array_equal(valid_keypoints_no_pose, np.empty(0))
+        npt.assert_array_equal(keypoints_scores_no_pose, np.empty(0))
+        npt.assert_array_equal(keypoints_conns_no_pose, np.empty(0))
 
     def test_get_results_multi(self, movenet_config, model_dir):
         # prediction for multi model is in shape of [1,6,56]
@@ -240,35 +193,7 @@ class TestPredictor:
             keypoints_scores_no_pose,
             keypoints_conns_no_pose,
         ) = movenet_predictor._get_results_multi(prediction_no_pose)
-        npt.assert_array_equal(
-            x=bbox_no_pose,
-            y=np.zeros(0),
-            err_msg=(
-                "Unexpected bbox output for prediction with keypoint score below "
-                f"threshold got {bbox_no_pose} instead of {np.zeros(0)}"
-            ),
-        )
-        npt.assert_array_equal(
-            x=valid_keypoints_no_pose,
-            y=np.zeros(0),
-            err_msg=(
-                "Unexpected valid keypoint output for prediction with keypoint score "
-                f"below threshold got {valid_keypoints_no_pose} instead of {np.zeros(0)}"
-            ),
-        )
-        npt.assert_array_equal(
-            x=keypoints_scores_no_pose,
-            y=np.zeros(0),
-            err_msg=(
-                "Unexpected keypoint score output for prediction with keypoint score "
-                f"below threshold got {keypoints_scores_no_pose} instead of {np.zeros(0)}"
-            ),
-        )
-        npt.assert_array_equal(
-            x=keypoints_conns_no_pose,
-            y=np.zeros(0),
-            err_msg=(
-                "Unexpected keypoint connection output for prediction with keypoint "
-                f"score below threshold got {keypoints_conns_no_pose} instead of {np.zeros(0)}"
-            ),
-        )
+        npt.assert_array_equal(bbox_no_pose, np.empty((0, 4)))
+        npt.assert_array_equal(valid_keypoints_no_pose, np.empty(0))
+        npt.assert_array_equal(keypoints_scores_no_pose, np.empty(0))
+        npt.assert_array_equal(keypoints_conns_no_pose, np.empty(0))

--- a/tests/pipeline/nodes/model/posenetv1/test_posenet.py
+++ b/tests/pipeline/nodes/model/posenetv1/test_posenet.py
@@ -63,11 +63,11 @@ class TestPoseNet:
         posenet = Node(posenet_type)
         output = posenet.run({"img": no_human_img})
         expected_output = {
-            "bboxes": np.zeros(0),
-            "keypoints": np.zeros(0),
-            "keypoint_scores": np.zeros(0),
-            "keypoint_conns": np.zeros(0),
-            "bbox_labels": np.zeros(0),
+            "bboxes": np.empty((0, 4)),
+            "keypoints": np.empty(0),
+            "keypoint_scores": np.empty(0),
+            "keypoint_conns": np.empty(0),
+            "bbox_labels": np.empty(0),
         }
         assert output.keys() == expected_output.keys(), "missing keys"
         for i in expected_output.keys():


### PR DESCRIPTION
Closes https://github.com/aisingapore/PeekingDuck-Private/issues/77

- `bboxes` are now always `np.ndarray` type, guaranteed to have a shape of `(N, 4)`
- Empty keypoints are returned explicitly with `np.empty(0)` instead of `np.array(var_name)` where `var_name = []`.
- Updated tests to check for the updates return values