### PR TITLE
Feat: skip integrity check if offline

### DIFF
--- a/peekingduck/pipeline/nodes/base.py
+++ b/peekingduck/pipeline/nodes/base.py
@@ -337,9 +337,14 @@ class WeightsDownloaderMixin:
         if not weights_path.exists():
             self.logger.warning("No weights detected.")
             return False
-        if self.sha256sum(weights_path).hexdigest() != self._get_weights_checksum():
-            self.logger.warning("Weights file is corrupted/out-of-date.")
-            return False
+        try:
+            if self.sha256sum(weights_path).hexdigest() != self._get_weights_checksum():
+                self.logger.warning("Weights file is corrupted/out-of-date.")
+                return False
+        except requests.exceptions.ConnectionError:
+            self.logger.warning(
+                "Skipped weights file integrity check due to network connectivity error."
+            )
         return True
 
     @staticmethod

--- a/peekingduck/pipeline/nodes/input/utils/preprocess.py
+++ b/peekingduck/pipeline/nodes/input/utils/preprocess.py
@@ -17,20 +17,12 @@ Preprocessing functions for input nodes
 """
 
 import logging
-from typing import Any, Tuple
+from typing import Any
 
 import cv2
 import numpy as np
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
-
-
-def get_res(stream: Any) -> Tuple[int, int]:
-    """Gets the resolution for the video frame"""
-    width = int(stream.get(cv2.CAP_PROP_FRAME_WIDTH))
-    height = int(stream.get(cv2.CAP_PROP_FRAME_HEIGHT))
-
-    return width, height
 
 
 def mirror(frame: np.ndarray) -> np.ndarray:

--- a/peekingduck/pipeline/nodes/input/utils/read.py
+++ b/peekingduck/pipeline/nodes/input/utils/read.py
@@ -30,13 +30,15 @@ import cv2
 from peekingduck.pipeline.nodes.input.utils.png_reader import PNGReader
 from peekingduck.pipeline.nodes.input.utils.preprocess import mirror
 
+GOOGLE_DNS = "8.8.8.8"
+
 
 def has_internet() -> bool:
     """Checks for internet connectivity by making a HEAD request to one of
     Google's public DNS servers.
     """
     # Suppress bandit B309 as PeekingDuck is meant to run on Python >= 3.6
-    connection = http.client.HTTPSConnection("8.8.8.8", timeout=5)  # nosec
+    connection = http.client.HTTPSConnection(GOOGLE_DNS, timeout=5)  # nosec
     try:
         connection.request("HEAD", "/")
         return True

--- a/peekingduck/pipeline/nodes/input/utils/read.py
+++ b/peekingduck/pipeline/nodes/input/utils/read.py
@@ -19,6 +19,7 @@ Reader functions for input nodes
 import logging
 import platform
 import queue
+from abc import ABC, abstractmethod
 from pathlib import Path
 from threading import Event, Thread
 from typing import Any, Tuple, Union
@@ -29,16 +30,10 @@ from peekingduck.pipeline.nodes.input.utils.png_reader import PNGReader
 from peekingduck.pipeline.nodes.input.utils.preprocess import mirror
 
 
-class VideoThread:
-    """
-    Videos will be threaded to improve FPS by reducing I/O blocking latency.
-    """
+class VideoReader(ABC):
+    """Class to read in videos and images."""
 
-    # pylint: disable=too-many-instance-attributes
-
-    def __init__(
-        self, input_source: Union[int, str], mirror_image: bool, buffering: bool
-    ) -> None:
+    def __init__(self, input_source: Union[int, str], mirror_image: bool) -> None:
         assert isinstance(input_source, (int, str))
         if isinstance(input_source, int):
             if platform.system().startswith("Windows"):
@@ -51,14 +46,86 @@ class VideoThread:
         else:
             self.stream = cv2.VideoCapture(input_source)
         if not self.stream.isOpened():
-            raise ValueError(f"Camera or video input not detected: {input_source}")
+            raise ValueError(f"Video or image path incorrect: {input_source}")
+        self._frame_counter = 0
         self.logger = logging.getLogger(type(self).__name__)
         self.mirror = mirror_image
+
+    def __del__(self) -> None:
+        # Note: self.logger.debug below crashes on Nvidia Jetson Xavier Ubuntu 18.04 python 3.6
+        #       but does not crash on Intel MacBook Pro Ubuntu 20.04 python 3.7
+        # self.logger.debug("__del__")
+        self.stream.release()
+
+    @abstractmethod
+    def read_frame(self) -> Tuple[bool, Any]:
+        """Reads the frame."""
+
+    def shutdown(self) -> None:
+        """Shuts down this class.
+        Cannot be merged into __del__ as threading code needs to run here.
+        Dummy method left here for consistency with VideoThread class.
+        """
+        self.logger.debug("shutdown")
+
+    @property
+    @abstractmethod
+    def queue_size(self) -> int:
+        """Get buffer queue size
+
+        Returns:
+            int: number of frames in buffer
+        """
+
+    @property
+    def fps(self) -> float:
+        """Get FPS of videofile
+
+        Returns:
+            int: number indicating FPS
+        """
+        fps = self.stream.get(cv2.CAP_PROP_FPS)
+        return fps
+
+    @property
+    def frame_count(self) -> int:
+        """Get total number of frames of file
+
+        Returns:
+            int: number indicating frame count
+        """
+        num_frames = self.stream.get(cv2.CAP_PROP_FRAME_COUNT)
+        return int(num_frames)
+
+    @property
+    def resolution(self) -> Tuple[int, int]:
+        """Get resolution of the file.
+
+        Returns:
+            width(int): width of resolution
+            height(int): heigh of resolution
+        """
+        width = self.stream.get(cv2.CAP_PROP_FRAME_WIDTH)
+        height = self.stream.get(cv2.CAP_PROP_FRAME_HEIGHT)
+        return int(width), int(height)
+
+
+class VideoThread(VideoReader):
+    """
+    Videos will be threaded to improve FPS by reducing I/O blocking latency.
+    """
+
+    # pylint: disable=too-many-instance-attributes
+
+    def __init__(
+        self, input_source: Union[int, str], mirror_image: bool, buffering: bool
+    ) -> None:
+        super().__init__(input_source, mirror_image)
+        self.logger = logging.getLogger(type(self).__name__)
         # events to coordinate threading
         self.is_done = Event()
         self.is_thread_start = Event()
         # frame storage and buffering
-        self.frame_counter = 0
         self.frame = None
         self.prev_frame = None
         self.buffer = buffering
@@ -67,13 +134,6 @@ class VideoThread:
         self.thread = Thread(target=self._reading_thread, args=(), daemon=True)
         self.thread.start()
         self.is_thread_start.wait()
-
-    def __del__(self) -> None:
-        """
-        Release acquired resources here.
-        """
-        self.logger.debug("VideoThread.__del__")
-        self.stream.release()
 
     def shutdown(self) -> None:
         """
@@ -94,7 +154,7 @@ class VideoThread:
                 if not ret:
                     self.logger.debug(
                         f"_reading_thread: ret={ret}, "
-                        f"#frames read={self.frame_counter}"
+                        f"#frames read={self._frame_counter}"
                     )
                     self.is_done.set()
                 else:
@@ -102,7 +162,7 @@ class VideoThread:
                         frame = mirror(frame)
                     self.frame = frame
                     self.is_thread_start.set()  # thread really started
-                    self.frame_counter += 1
+                    self._frame_counter += 1
                     if self.buffer:
                         self.queue.put(self.frame)
 
@@ -129,26 +189,6 @@ class VideoThread:
                 return True, self.frame
 
     @property
-    def fps(self) -> float:
-        """Get FPS of videofile
-
-        Returns:
-            int: number indicating FPS
-        """
-        fps = self.stream.get(cv2.CAP_PROP_FPS)
-        return fps
-
-    @property
-    def frame_count(self) -> int:
-        """Get total number of frames of file
-
-        Returns:
-            int: number indicating frame count
-        """
-        num_frames = self.stream.get(cv2.CAP_PROP_FRAME_COUNT)
-        return int(num_frames)
-
-    @property
     def queue_size(self) -> int:
         """Get buffer queue size
 
@@ -157,47 +197,11 @@ class VideoThread:
         """
         return self.queue.qsize()
 
-    @property
-    def resolution(self) -> Tuple[int, int]:
-        """Get resolution of the camera device used.
 
-        Returns:
-            width(int): width of input resolution
-            height(int): heigh of input resolution
-        """
-        width = self.stream.get(cv2.CAP_PROP_FRAME_WIDTH)
-        height = self.stream.get(cv2.CAP_PROP_FRAME_HEIGHT)
-        return int(width), int(height)
-
-
-class VideoNoThread:
+class VideoNoThread(VideoReader):
     """
     No threading to deal with recorded videos and images.
     """
-
-    def __init__(self, input_source: Union[int, str], mirror_image: bool) -> None:
-        assert isinstance(input_source, (int, str))
-        if isinstance(input_source, int):
-            if platform.system().startswith("Windows"):
-                # to eliminate opencv's "[WARN] terminating async callback" on Windows
-                self.stream = cv2.VideoCapture(input_source, cv2.CAP_DSHOW)
-            else:
-                self.stream = cv2.VideoCapture(input_source)
-        elif Path(input_source.lower()).suffix == ".png":
-            self.stream = PNGReader(input_source)
-        else:
-            self.stream = cv2.VideoCapture(input_source)
-        if not self.stream.isOpened():
-            raise ValueError(f"Video or image path incorrect: {input_source}")
-        self._frame_counter = 0
-        self.logger = logging.getLogger(type(self).__name__)
-        self.mirror = mirror_image
-
-    def __del__(self) -> None:
-        # Note: self.logger.debug below crashes on Nvidia Jetson Xavier Ubuntu 18.04 python 3.6
-        #       but does not crash on Intel MacBook Pro Ubuntu 20.04 python 3.7
-        # self.logger.debug("VideoNoThread.__del__")
-        self.stream.release()
 
     def read_frame(self) -> Tuple[bool, Any]:
         """
@@ -212,35 +216,6 @@ class VideoNoThread:
             self._frame_counter += 1
         return ret, frame
 
-    # pylint: disable=R0201
-    def shutdown(self) -> None:
-        """
-        Shuts down this class.
-        Cannot be merged into __del__ as threading code needs to run here.
-        Dummy method left here for consistency with VideoThread class.
-        """
-        self.logger.debug("VideoNoThread.shutdown")
-
-    @property
-    def fps(self) -> float:
-        """Get FPS of videofile
-
-        Returns:
-            int: number indicating FPS
-        """
-        fps = self.stream.get(cv2.CAP_PROP_FPS)
-        return fps
-
-    @property
-    def frame_count(self) -> int:
-        """Get total number of frames of file
-
-        Returns:
-            int: number indicating frame count
-        """
-        num_frames = self.stream.get(cv2.CAP_PROP_FRAME_COUNT)
-        return int(num_frames)
-
     @property
     def queue_size(self) -> int:
         """Get buffer queue size
@@ -249,15 +224,3 @@ class VideoNoThread:
             int: number of frames in buffer
         """
         return 0
-
-    @property
-    def resolution(self) -> Tuple[int, int]:
-        """Get resolution of the file.
-
-        Returns:
-            width(int): width of resolution
-            height(int): heigh of resolution
-        """
-        width = self.stream.get(cv2.CAP_PROP_FRAME_WIDTH)
-        height = self.stream.get(cv2.CAP_PROP_FRAME_HEIGHT)
-        return int(width), int(height)

--- a/peekingduck/pipeline/nodes/input/visual.py
+++ b/peekingduck/pipeline/nodes/input/visual.py
@@ -259,7 +259,7 @@ class Node(AbstractNode):  # pylint: disable=too-many-instance-attributes
             "filename": self._file_name if self._file_name else self.filename,
             "pipeline_end": True,
             "saved_video_fps": self._fps
-            if (0 < self._fps <= 200)
+            if 0 < self._fps <= 200
             else self.saved_video_fps,
         }
         if self.videocap:

--- a/tests/pipeline/nodes/draw/test_tag.py
+++ b/tests/pipeline/nodes/draw/test_tag.py
@@ -16,12 +16,11 @@
 Test for draw tag node
 """
 
-from contextlib import contextmanager
-
 import numpy as np
 import pytest
 
 from peekingduck.pipeline.nodes.draw.tag import Node
+from tests.conftest import not_raises
 
 
 @pytest.fixture
@@ -187,11 +186,3 @@ class TestTag:
         # This second run below should not throw an error if "show" config is unchanged
         with not_raises(TypeError):
             node.run(input1)
-
-
-@contextmanager
-def not_raises(exception):
-    try:
-        yield
-    except exception:
-        raise pytest.fail(f"DID RAISE EXCEPTION: {exception}")

--- a/tests/pipeline/nodes/input/test_input_threading.py
+++ b/tests/pipeline/nodes/input/test_input_threading.py
@@ -71,13 +71,11 @@ def test_input_threading():
     """Run input threading unit test.
 
     This test will do the following:
-    1. Backup original pipeline_config.yml in Peeking Duck directory
-    2. Run input live test 1 without threading with custom pipeline_config.yml file
+    1. Run input live test 1 without threading with threading_pipeline_config.yml file
        The test comprises input.visual, model.yolo and dabble.fps
-    3. Run input live test 2 with threading with custom pipeline_config.yml file
+    2. Run input live test 2 with threading with threading_pipeline_config.yml file
        The test comprises input.visual, model.yolo and dabble.fps
-    4. Restore original pipeline_config.yml
-    5. Check average FPS from 2 is higher than 1
+    3. Check average FPS from 2 is higher than 1
     """
 
     def run_rtsp_test(url: str, threading: bool) -> float:

--- a/tests/pipeline/nodes/input/test_visual.py
+++ b/tests/pipeline/nodes/input/test_visual.py
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import http.client
 from contextlib import contextmanager
+from unittest import TestCase, mock
 
+import cv2
 import numpy as np
 import pytest
-from unittest import TestCase
 
 from peekingduck.pipeline.nodes.input.visual import Node
+from tests.conftest import assert_msg_in_logs
 
 
 @contextmanager
@@ -72,9 +75,19 @@ class TestMediaReader:
             )
 
     def test_reader_run_fine_on_empty_folder(self):
-        with not_raises(FileNotFoundError) as excinfo:
+        with not_raises(FileNotFoundError):
             reader = create_reader()
             reader.run({})
+
+    @mock.patch.object(cv2.VideoCapture, "isOpened", return_value=False)
+    @mock.patch.object(http.client.HTTPSConnection, "request", side_effect=OSError(101))
+    def test_show_connectivity_warning_for_url_source(self, *_):
+        with pytest.raises(ValueError), TestCase.assertLogs(
+            "VideoNoThread"
+        ) as captured:
+            Node(source="https://storage.googleapis.com/peekingduck/videos/wave.mp4")
+        print(captured.records)
+        assert_msg_in_logs("Possible network connectivity error.", captured.records)
 
     def test_reader_reads_one_image(self, create_input_image):
         filename = "image1.png"

--- a/tests/pipeline/nodes/input/test_visual.py
+++ b/tests/pipeline/nodes/input/test_visual.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import http.client
-from contextlib import contextmanager
 from unittest import TestCase, mock
 
 import cv2
@@ -21,15 +20,7 @@ import numpy as np
 import pytest
 
 from peekingduck.pipeline.nodes.input.visual import Node
-from tests.conftest import assert_msg_in_logs
-
-
-@contextmanager
-def not_raises(exception):
-    try:
-        yield
-    except exception:
-        raise pytest.fail(f"DID RAISE EXCEPTION: {exception}")
+from tests.conftest import assert_msg_in_logs, not_raises
 
 
 def create_reader(source=None):


### PR DESCRIPTION
Closes https://github.com/aisingapore/PeekingDuck-Private/issues/93

- Skips weights integrity check and prints warning on `ConnectionErrror`
- Prints warning about possible connectivity issues when `input.visual` source is a URL
- Make `VideoThread` and `VideoNoThread` inherit from `VideoReader`
  - Abstract `read_frame()` and `queue_size` for the child classes to implement