### PR TITLE
fix bug: input not mirrored if mirror_image=True and threading=False

### DIFF
--- a/peekingduck/pipeline/nodes/input/utils/read.py
+++ b/peekingduck/pipeline/nodes/input/utils/read.py
@@ -238,6 +238,8 @@ class VideoNoThread(VideoReader):
                 f"read_frame: ret={ret}, #frames read={self._frame_counter}"
             )
         else:
+            if self.mirror:
+                frame = mirror(frame)
             self._frame_counter += 1
         return ret, frame
 


### PR DESCRIPTION
`input.visual` `mirror_image` does not work when `threading` is `False` due to bug in `VideoNoThread->read_frame()`.

This PR fixes this bug.