### PR TITLE
bug fix: mirror_image not working when threading is False

### DIFF
--- a/peekingduck/pipeline/nodes/input/utils/read.py
+++ b/peekingduck/pipeline/nodes/input/utils/read.py
@@ -209,6 +209,8 @@ class VideoNoThread:
                 f"read_frame: ret={ret}, #frames read={self._frame_counter}"
             )
         else:
+            if self.mirror:
+                frame = mirror(frame)
             self._frame_counter += 1
         return ret, frame
 


### PR DESCRIPTION
`input.visual` `mirror_image` not working when `threading` is `False` due to bug in `VideoNoThread->read_frame()`.

This PR fixes the bug.