### PR TITLE
bug fix: VideoThread.__del__ crashes on python 3.7

### DIFF
--- a/peekingduck/pipeline/nodes/input/utils/read.py
+++ b/peekingduck/pipeline/nodes/input/utils/read.py
@@ -72,7 +72,8 @@ class VideoThread:
         """
         Release acquired resources here.
         """
-        self.logger.debug("VideoThread.__del__")
+        # Note: self.logger is 'None' on python 3.7 but works on python 3.8+
+        # self.logger.debug("VideoThread.__del__")
         self.stream.release()
 
     def shutdown(self) -> None:


### PR DESCRIPTION
Closes https://github.com/aisingapore/PeekingDuck-Private/issues/102

Remove debug print statement in `VideoThread.__del__()` as it crashes on python 3.7
Works on python 3.8+ though.