### PR TITLE
Feat: callbacks

### DIFF
--- a/docs/source/tutorials/04_peaking_duck.rst
+++ b/docs/source/tutorials/04_peaking_duck.rst
@@ -728,6 +728,47 @@ as follows:
               ]
       - output.screen
 
+The following table illustrates how the callback definitions map to their respective
+callback functions:
+
++---------------------------------------------------------------+----------------------------------------------------+---------------------------------------------+
+| Definition                                                    | Function                                           | Script location                             |
++===============================================================+====================================================+=============================================+
+| ``my_callback::my_callback_function``                         | ``my_callback_function()``                         | ``callbacks/my_callback.py``                |
++---------------------------------------------------------------+----------------------------------------------------+                                             +
+| ``my_callback::MyCallbackClass::my_callback_static_method``   | ``MyCallbackClass.my_callback_static_method()``    |                                             |
++---------------------------------------------------------------+                                                    +                                             +
+| ``my_callback::my_callback_obj::my_callback_static_method``   |                                                    |                                             |
++---------------------------------------------------------------+----------------------------------------------------+                                             +
+| ``my_callback::MyCallbackClass::my_callback_class_method``    | ``MyCallbackClass.my_callback_class_method()``     |                                             |
++---------------------------------------------------------------+                                                    +                                             +
+| ``my_callback::my_callback_obj::my_callback_class_method``    |                                                    |                                             |
++---------------------------------------------------------------+----------------------------------------------------+                                             +
+| ``my_callback::my_callback_obj::my_callback_instance_method`` | ``MyCallbackClass::my_callback_instance_method()`` |                                             |
++---------------------------------------------------------------+----------------------------------------------------+---------------------------------------------+
+| ``cb_dir.my_cb::my_cb_function``                              | ``my_cb_function()``                               | ``callbacks/cb_dir/my_cb.py``               |
++---------------------------------------------------------------+----------------------------------------------------+---------------------------------------------+
+
+Running the pipeline with :greenbox:`peekingduck run` should give the following output:
+
+   .. admonition:: Terminal Session
+
+      | [Truncated]
+      |
+      | 2022-11-09 09:04:04 peekingduck.declarative_loader  INFO:  Config for node input.visual is updated to: 'callbacks': {'run_end': ['my_callback::my_callback_function', 'my_callback::MyCallbackClass::my_callback_static_method', 'my_callback::MyCallbackClass::my_callback_class_method', 'my_callback::my_callback_obj::my_callback_static_method', 'my_callback::my_callback_obj::my_callback_class_method', 'my_callback::my_callback_obj::my_callback_instance_method', 'cb_dir.my_cb::my_cb_function']}
+      | 2022-11-09 09:04:04 peekingduck.pipeline.nodes.input.visual  INFO:  Input size: 710 by 540
+      | 2022-11-09 09:04:04 peekingduck.declarative_loader  INFO:  Initializing output.screen node...
+      | Called my_callback_function
+      | Called my_callback_static_method
+      | Called my_callback_class_method
+      | Called my_callback_static_method
+      | Called my_callback_class_method
+      | Called my_callback_instance_method
+      | Called my_cb_function
+      |
+      | [Truncated]
+
+
 
 Interfacing with SQL Using Callbacks
 ------------------------------------

--- a/docs/source/tutorials/04_peaking_duck.rst
+++ b/docs/source/tutorials/04_peaking_duck.rst
@@ -580,3 +580,398 @@ Do a :greenbox:`peekingduck run` and you will see the following display:
       Count People Walking in a Zone
 
 
+.. _tutorial_callbacks:
+
+Using Callbacks
+===============
+
+While PeekingDuck allows you to extend its capabilities through custom nodes, it
+may not be the most optimal/efficient approach in some cases. For example, if you
+are trying to bring in PeekingDuck into an existing codebase/project, it may not
+be desirable to refactor the existing codebase such that it can be constructed/initialized
+in a custom node.
+
+
+Interfacing with SQL Using Callbacks
+------------------------------------
+
+This tutorial replicates the earlier :ref:`Interfacing with SQL<tutorial_sql>` tutorial
+but uses callbacks instead of custom nodes.
+
+   .. note::
+
+      The above tutorial assumes ``sqlite3`` has been installed in your system. |br|
+      If your system does not have ``sqlite3``, please see the `SQLite Home Page 
+      <http://www.sqlite.org/>`_ for installation instructions.
+
+The following steps are necessary to prepare the files and folder structure required
+for this tutorial:
+
+   #. Create and initialize a new PeekingDuck project in a folder named
+      ``callbacks_wave_project``.
+   #. Create a ``dabble.wave`` custom node.
+   #. Create a ``sql_callback.py`` in the ``callbacks/`` folder.
+   #. Copy `wave.mp4 <https://storage.googleapis.com/peekingduck/videos/wave.mp4>`_
+      into the folder.
+
+You should end up with the following folder structure:
+
+   .. parsed-literal::
+
+      \ :blue:`callbacks_wave_project/`
+      ├── pipeline_config.yml
+      ├── \ :blue:`callbacks/`
+      │   └── sql_callback.py
+      ├── \ :blue:`src/`
+      │   └── \ :blue:`custom_nodes/`
+      │       ├── \ :blue:`configs/`
+      │       │   └── \ :blue:`dabble/`
+      │       │       └── wave.yml
+      │       └── \ :blue:`dabble/`
+      │           └── wave.py
+      └── wave.mp4
+
+Edit the following **files** as described below:
+
+#. **src/custom_nodes/configs/dabble/wave.yml**:
+
+   .. code-block:: yaml
+      :linenos:
+
+      # Dabble node has both input and output
+      input: ["img", "bboxes", "bbox_scores", "keypoints", "keypoint_scores"]
+      output: ["hand_direction", "num_waves"]
+
+      callbacks: {}
+
+   The additional ``callbacks: {}`` config allows us to override it later in ``pipeline_config.yml``
+   to define the callback functions to use.
+
+#. **src/custom_nodes/dabble/wave.py**:
+
+   .. container:: toggle
+
+      .. container:: header
+
+         **Show/Hide Code for wave.py**
+
+      .. code-block:: python
+         :linenos:
+
+         """
+         Custom node to show keypoints and count the number of times the person's hand is waved
+         """
+
+         from typing import Any, Dict, List, Tuple
+
+         import cv2
+         from peekingduck.pipeline.nodes.abstract_node import AbstractNode
+
+         # setup global constants
+         FONT = cv2.FONT_HERSHEY_SIMPLEX
+         WHITE = (255, 255, 255)  # opencv loads file in BGR format
+         YELLOW = (0, 255, 255)
+         THRESHOLD = 0.6  # ignore keypoints below this threshold
+         KP_RIGHT_SHOULDER = 6  # PoseNet's skeletal keypoints
+         KP_RIGHT_WRIST = 10
+
+
+         def map_bbox_to_image_coords(
+             bbox: List[float], image_size: Tuple[int, int]
+         ) -> Tuple[int, ...]:
+             """First helper function to convert relative bounding box coordinates to
+             absolute image coordinates.
+             Bounding box coords ranges from 0 to 1
+             where (0, 0) = image top-left, (1, 1) = image bottom-right.
+
+             Args:
+                 bbox (List[float]): List of 4 floats x1, y1, x2, y2
+                 image_size (Tuple[int, int]): Width, Height of image
+
+             Returns:
+                 Tuple[int, ...]: x1, y1, x2, y2 in integer image coords
+             """
+             width, height = image_size[0], image_size[1]
+             x1, y1, x2, y2 = bbox
+             x1 *= width
+             x2 *= width
+             y1 *= height
+             y2 *= height
+             return int(x1), int(y1), int(x2), int(y2)
+
+         def map_keypoint_to_image_coords(
+             keypoint: List[float], image_size: Tuple[int, int]
+         ) -> Tuple[int, ...]:
+             """Second helper function to convert relative keypoint coordinates to
+             absolute image coordinates.
+             Keypoint coords ranges from 0 to 1
+             where (0, 0) = image top-left, (1, 1) = image bottom-right.
+
+             Args:
+                 bbox (List[float]): List of 2 floats x, y (relative)
+                 image_size (Tuple[int, int]): Width, Height of image
+
+             Returns:
+                 Tuple[int, ...]: x, y in integer image coords
+             """
+             width, height = image_size[0], image_size[1]
+             x, y = keypoint
+             x *= width
+             y *= height
+             return int(x), int(y)
+
+         def draw_text(img, x, y, text_str: str, color_code):
+             """Helper function to call opencv's drawing function,
+             to improve code readability in node's run() method.
+             """
+             cv2.putText(
+                 img=img,
+                 text=text_str,
+                 org=(x, y),
+                 fontFace=cv2.FONT_HERSHEY_SIMPLEX,
+                 fontScale=0.4,
+                 color=color_code,
+                 thickness=2,
+             )
+
+         class Node(AbstractNode):
+             """Custom node to display keypoints and count number of hand waves
+
+             Args:
+                 config (:obj:`Dict[str, Any]` | :obj:`None`): Node configuration.
+             """
+
+             def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:
+                 super().__init__(config, node_path=__name__, **kwargs)
+                 # setup object working variables
+                 self.right_wrist = None
+                 self.direction = None
+                 self.num_direction_changes = 0
+                 self.num_waves = 0
+
+             def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:  # type: ignore
+                 """This node draws keypoints and count hand waves.
+
+                 Args:
+                     inputs (dict): Dictionary with keys
+                         "img", "bboxes", "bbox_scores", "keypoints", "keypoint_scores".
+
+                 Returns:
+                     outputs (dict): Empty dictionary.
+                 """
+                 # get required inputs from pipeline
+                 img = inputs["img"]
+                 bboxes = inputs["bboxes"]
+                 bbox_scores = inputs["bbox_scores"]
+                 keypoints = inputs["keypoints"]
+                 keypoint_scores = inputs["keypoint_scores"]
+
+                 img_size = (img.shape[1], img.shape[0])  # image width, height
+
+                 # get bounding box confidence score and draw it at the
+                 # left-bottom (x1, y2) corner of the bounding box (offset by 30 pixels)
+                 the_bbox = bboxes[0]  # image only has one person
+                 the_bbox_score = bbox_scores[0]  # only one set of scores
+
+                 x1, y1, x2, y2 = map_bbox_to_image_coords(the_bbox, img_size)
+                 score_str = f"BBox {the_bbox_score:0.2f}"
+                 cv2.putText(
+                     img=img,
+                     text=score_str,
+                     org=(x1, y2 - 30),  # offset by 30 pixels
+                     fontFace=cv2.FONT_HERSHEY_SIMPLEX,
+                     fontScale=1.0,
+                     color=WHITE,
+                     thickness=3,
+                 )
+
+                 # hand wave detection using a simple heuristic of tracking the
+                 # right wrist movement
+                 the_keypoints = keypoints[0]  # image only has one person
+                 the_keypoint_scores = keypoint_scores[0]  # only one set of scores
+                 right_wrist = None
+                 right_shoulder = None
+
+                 for i, keypoints in enumerate(the_keypoints):
+                     keypoint_score = the_keypoint_scores[i]
+
+                     if keypoint_score >= THRESHOLD:
+                         x, y = map_keypoint_to_image_coords(keypoints.tolist(), img_size)
+                         x_y_str = f"({x}, {y})"
+
+                         if i == KP_RIGHT_SHOULDER:
+                             right_shoulder = keypoints
+                             the_color = YELLOW
+                         elif i == KP_RIGHT_WRIST:
+                             right_wrist = keypoints
+                             the_color = YELLOW
+                         else:  # generic keypoint
+                             the_color = WHITE
+
+                         draw_text(img, x, y, x_y_str, the_color)
+
+                 if right_wrist is not None and right_shoulder is not None:
+                     # only count number of hand waves after we have gotten the
+                     # skeletal poses for the right wrist and right shoulder
+                     if self.right_wrist is None:
+                         self.right_wrist = right_wrist  # first wrist data point
+                     else:
+                         # wait for wrist to be above shoulder to count hand wave
+                         if right_wrist[1] > right_shoulder[1]:
+                             pass
+                         else:
+                             if right_wrist[0] < self.right_wrist[0]:
+                                 direction = "left"
+                             else:
+                                 direction = "right"
+
+                             if self.direction is None:
+                                 self.direction = direction  # first direction data point
+                             else:
+                                 # check if hand changes direction
+                                 if direction != self.direction:
+                                     self.num_direction_changes += 1
+                                 # every two hand direction changes == one wave
+                                 if self.num_direction_changes >= 2:
+                                     self.num_waves += 1
+                                     self.num_direction_changes = 0  # reset direction count
+
+                             self.right_wrist = right_wrist  # save last position
+                             self.direction = direction
+
+                     wave_str = f"#waves = {self.num_waves}"
+                     draw_text(img, 20, 30, wave_str, YELLOW)
+
+                 return {
+                     "hand_direction": self.direction if self.direction is not None else "None",
+                     "num_waves": self.num_waves,
+                 }
+
+   Note that we still use a custom node for the "wave" logic as we need to produce
+   custom outputs such as ``hand_direction`` and ``num_waves``.
+
+#. ``callbacks/sql_callback.py``:
+
+   .. container:: toggle
+
+      .. container:: header
+
+         **Show/Hide Code for sql_callback.py**
+
+      .. code-block:: python
+         :linenos:
+
+         """
+         Callbacks for interacting with an external database.
+         """
+
+         import logging
+         import sqlite3
+         from datetime import datetime
+         from typing import Any, Dict
+
+         DB_FILE = "wave.db"  # name of database file
+
+
+         class SQLCallback:
+             """Interacts with a SQLite database and provides a callback method to
+             trigger updates.
+             """
+
+             def __init__(self) -> None:
+                 self.logger = logging.getLogger(__name__)
+                 self.conn = None
+                 try:
+                     self.conn = sqlite3.connect(DB_FILE)
+                     self.logger.info(f"Connected to {DB_FILE}")
+                     sql = """ CREATE TABLE IF NOT EXISTS wavetable (
+                                 datetime text,
+                                 hand_direction text,
+                                 wave_count integer
+                            ); """
+                     cur = self.conn.cursor()
+                     cur.execute(sql)
+                 except sqlite3.Error as e:
+                     self.logger.info(f"SQL Error: {e}")
+
+             def track_wave_callback(self, data_pool: Dict[str, Any]) -> None:
+                 hand_direction = data_pool["hand_direction"]
+                 num_waves = data_pool["num_waves"]
+                 self.update_db(hand_direction, num_waves)
+
+             def update_db(self, hand_direction: str, num_waves: int) -> None:
+                 """Helper function to save current time stamp, hand direction and
+                 wave count into DB wavetable.
+                 """
+                 now = datetime.now()
+                 dt_str = f"{now:%Y-%m-%d %H:%M:%S}"
+                 sql = """ INSERT INTO wavetable(datetime,hand_direction,wave_count)
+                           values (?,?,?) """
+                 cur = self.conn.cursor()
+                 cur.execute(sql, (dt_str, hand_direction, num_waves))
+                 self.conn.commit()
+
+
+         sql_callback_obj = SQLCallback()
+
+   We have recreated the ``output.sqlite`` node into a standalone class. As it no
+   longer inherits from ``AbstractNode``, having a ``run()`` method is not necessary
+   anymore. Instead, we implement a ``track_wave_callback()`` method which will
+   be used update the database with the require information. As ``track_wave_callback()``
+   is an instance method, we need to instantiate ``SQLCallback`` as ``sql_callback_obj``
+   in order to use it.
+
+#. ``pipeline_config.yml``:
+
+   .. code-block:: yaml
+      :linenos:
+
+      nodes:
+      - input.visual:
+          source: wave.mp4
+      - model.yolo
+      - model.posenet
+      - custom_nodes.dabble.wave:
+          callbacks:
+            run_end: ["sql_callback::sql_callback_obj::track_wave_callback"]
+      - draw.poses
+      - output.screen
+
+   To use the callback function, we override the ``callbacks`` config option in
+   ``custom_nodes.dabble.wave``. The key ``run_end`` specifies that the callback
+   function will be invoked after the node's ``run()`` method. To specify the callback
+   function to be invoked we format the string as ``<script name>::<instance name>::<instance method name>``.
+
+Run this project with :greenbox:`peekingduck run`, and when completed, a ``wave.db``
+database file will be generated. We can examine the created database using similar
+commands as the :ref:`Interfacing with SQL<tutorial_sql>` tutorial:
+
+   .. admonition:: Terminal Session
+
+      | \ :blue:`[~user/wave_project]` \ > \ :green:`sqlite3` \
+      | SQLite version 3.39.2 2022-07-21 15:24:47
+      | Enter ".help" for usage hints.
+      | Connected to a transient in-memory database.
+      | Use ".open FILENAME" to reopen on a persistent database.
+      | @sqlite> \ :green:`.open wave.db` \ 
+      | @sqlite> \ :green:`.schema wavetable` \ 
+      | CREATE TABLE wavetable (
+      |                         datetime text,
+      |                         hand_direction text,
+      |                         wave_count integer
+      |                    );
+      | @sqlite> \ :green:`select * from wavetable where wave_count > 0 limit 5;` \ 
+      | 2022-11-08 13:30:06|left|1
+      | 2022-11-08 13:30:06|right|1
+      | 2022-11-08 13:30:06|left|2
+      | 2022-11-08 13:30:06|left|2
+      | 2022-11-08 13:30:06|left|2
+      | @sqlite> \ :green:`select * from wavetable order by datetime desc limit 5;` \ 
+      | 2022-11-08 13:30:36|right|70
+      | 2022-11-08 13:30:36|left|71
+      | 2022-11-08 13:30:35|left|69
+      | 2022-11-08 13:30:35|left|69
+      | 2022-11-08 13:30:35|left|69
+
+Press :greenbox:`CTRL-D` to exit from ``sqlite3``.
+

--- a/docs/source/tutorials/04_peaking_duck.rst
+++ b/docs/source/tutorials/04_peaking_duck.rst
@@ -675,25 +675,29 @@ given the following directory structure and file contents:
       .. code-block:: python
          :linenos:
 
-         def my_callback_function(data_pool):
-             print("Called my_callback_function")
+         def general_function(data_pool):
+             print("Called general_function")
+             filename = data_pool["filename"]
+             print(f"  filename={filename}")
 
 
          class MyCallbackClass:
              @staticmethod
-             def my_callback_static_method(data_pool):
-                 print("Called my_callback_static_method")
+             def the_static_method(data_pool):
+                 print("Called the_static_method")
 
              @classmethod
-             def my_callback_class_method(cls, data_pool):
-                 print("Called my_callback_class_method")
+             def the_class_method(cls, data_pool):
+                 print("Called the_class_method")
 
-             def my_callback_instance_method(self, data_pool):
-                 print("Called my_callback_instance_method")
+             def the_instance_method(self, data_pool):
+                 print("Called the_instance_method")
+                 kp_scores = data_pool["keypoint_scores"][0]
+                 print(f"  num_keypoint_scores={len(kp_scores)}")
 
 
          # my_callback_obj has to be visible from my_callback.py's global scope
-         # to enable access to my_callback_instance_method()
+         # to enable access to the_instance_method()
          my_callback_obj = MyCallbackClass()
 
 
@@ -720,17 +724,22 @@ as follows:
       nodes:
       - input.visual:
           source: https://storage.googleapis.com/peekingduck/videos/wave.mp4
+      - model.posenet:
           callbacks:
+            run_begin:
+              [
+                "my_callback::MyCallbackClass::the_static_method",
+                "my_callback::MyCallbackClass::the_class_method",
+              ]
             run_end:
               [
-                "my_callback::my_callback_function",
-                "my_callback::MyCallbackClass::my_callback_static_method",
-                "my_callback::MyCallbackClass::my_callback_class_method",
-                "my_callback::my_callback_obj::my_callback_static_method",
-                "my_callback::my_callback_obj::my_callback_class_method",
-                "my_callback::my_callback_obj::my_callback_instance_method",
+                "my_callback::general_function",
+                "my_callback::my_callback_obj::the_static_method",
+                "my_callback::my_callback_obj::the_class_method",
+                "my_callback::my_callback_obj::the_instance_method",
                 "cb_dir.my_cb::my_cb_function",
               ]
+      - draw.poses
       - output.screen
 
 The following table illustrates how the callback definitions map to their respective
@@ -739,17 +748,17 @@ callback functions:
 +---------------------------------------------------------------+----------------------------------------------------+---------------------------------------------+
 | Definition                                                    | Function                                           | Script location                             |
 +===============================================================+====================================================+=============================================+
-| ``my_callback::my_callback_function``                         | ``my_callback_function()``                         | ``callbacks/my_callback.py``                |
+| ``my_callback::general_function``                             | ``general_function()``                             | ``callbacks/my_callback.py``                |
 +---------------------------------------------------------------+----------------------------------------------------+                                             +
-| ``my_callback::MyCallbackClass::my_callback_static_method``   | ``MyCallbackClass.my_callback_static_method()``    |                                             |
+| ``my_callback::MyCallbackClass::the_static_method``           | ``MyCallbackClass.the_static_method()``            |                                             |
 +---------------------------------------------------------------+                                                    +                                             +
-| ``my_callback::my_callback_obj::my_callback_static_method``   |                                                    |                                             |
+| ``my_callback::my_callback_obj::the_static_method``           |                                                    |                                             |
 +---------------------------------------------------------------+----------------------------------------------------+                                             +
-| ``my_callback::MyCallbackClass::my_callback_class_method``    | ``MyCallbackClass.my_callback_class_method()``     |                                             |
+| ``my_callback::MyCallbackClass::the_class_method``            | ``MyCallbackClass.the_class_method()``             |                                             |
 +---------------------------------------------------------------+                                                    +                                             +
-| ``my_callback::my_callback_obj::my_callback_class_method``    |                                                    |                                             |
+| ``my_callback::my_callback_obj::the_class_method``            |                                                    |                                             |
 +---------------------------------------------------------------+----------------------------------------------------+                                             +
-| ``my_callback::my_callback_obj::my_callback_instance_method`` | ``MyCallbackClass::my_callback_instance_method()`` |                                             |
+| ``my_callback::my_callback_obj::the_instance_method``         | ``MyCallbackClass::the_instance_method()``         |                                             |
 +---------------------------------------------------------------+----------------------------------------------------+---------------------------------------------+
 | ``cb_dir.my_cb::my_cb_function``                              | ``my_cb_function()``                               | ``callbacks/cb_dir/my_cb.py``               |
 +---------------------------------------------------------------+----------------------------------------------------+---------------------------------------------+
@@ -760,19 +769,25 @@ Running the pipeline with :greenbox:`peekingduck run` should give the following 
 
       | [Truncated]
       |
-      | 2022-11-09 09:04:04 peekingduck.declarative_loader  INFO:  Config for node input.visual is updated to: 'callbacks': {'run_end': ['my_callback::my_callback_function', 'my_callback::MyCallbackClass::my_callback_static_method', 'my_callback::MyCallbackClass::my_callback_class_method', 'my_callback::my_callback_obj::my_callback_static_method', 'my_callback::my_callback_obj::my_callback_class_method', 'my_callback::my_callback_obj::my_callback_instance_method', 'cb_dir.my_cb::my_cb_function']}
-      | 2022-11-09 09:04:04 peekingduck.pipeline.nodes.input.visual  INFO:  Input size: 710 by 540
-      | 2022-11-09 09:04:04 peekingduck.declarative_loader  INFO:  Initializing output.screen node...
-      | Called my_callback_function
-      | Called my_callback_static_method
-      | Called my_callback_class_method
-      | Called my_callback_static_method
-      | Called my_callback_class_method
-      | Called my_callback_instance_method
+      | 2022-12-01 17:33:23 peekingduck.declarative_loader  INFO:  Config for node model.posenet is updated to: 'callbacks': {'run_begin': ['my_callback::MyCallbackClass::the_static_method', 'my_callback::MyCallbackClass::the_class_method'], 'run_end': ['my_callback::general_function', 'my_callback::my_callback_obj::the_static_method', 'my_callback::my_callback_obj::the_class_method', 'my_callback::my_callback_obj::the_instance_method', 'cb_dir.my_cb::my_cb_function']}
+      | 2022-12-01 17:33:23 peekingduck.nodes.model.posenetv1.posenet_files.predictor  INFO:  PoseNet model loaded with following configs:
+      |         Model type: resnet,
+      |         Input resolution: (225, 225),
+      |         Max pose detection: 10,
+      |         Score threshold: 0.4
+      | 2022-12-01 17:33:26 peekingduck.declarative_loader  INFO:  Initializing draw.poses node...
+      | 2022-12-01 17:33:26 peekingduck.declarative_loader  INFO:  Initializing output.screen node...
+      | Called the_static_method
+      | Called the_class_method
+      | Called general_function
+      |   filename=video.mp4
+      | Called the_static_method
+      | Called the_class_method
+      | Called the_instance_method
+      |   num_keypoint_scores=17
       | Called my_cb_function
       |
       | [Truncated]
-
 
 
 Interfacing with SQL Using Callbacks

--- a/docs/source/tutorials/04_peaking_duck.rst
+++ b/docs/source/tutorials/04_peaking_duck.rst
@@ -613,17 +613,17 @@ For example, in the following pipeline config:
       :linenos:
 
       nodes:
-      - input.visual:
-      - model.posenet
+      - input.visual
+      - model.posenet:
           callbacks:
             run_begin: [<callback 1>]
-            run_end: [<callback 2>]
+            run_end: [<callback 2>, <callback 3>, <callback 4>]
       - draw.poses
       - output.screen
 
 After a image frame is read by :mod:`input.visual`, ``<callback 1>`` is invoked,
-followed by :mod:`model.posenet`'s ``run()`` method, and ``<callback 2>`` is invoked
-after that.
+followed by :mod:`model.posenet`'s ``run()`` method, then ``<callback 2>``, ``<callback 3>``,
+and ``<callback 4>`` are invoked after that.
 
 Callback Definition
 ^^^^^^^^^^^^^^^^^^^
@@ -647,6 +647,9 @@ the `EBNF notation <https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_f
       function        = ? name of callback function ?
       method          = ? name of class/static methods ?
       instance method = ? name of instance method ? 
+
+When using ``<instance name>::<instance method>`` for ``callback part``, the
+instance object has to be in the script's global scope. 
 
 The ``callbacks`` directory, which houses the scripts containing the callback functions,
 is expected to be at the same location of the pipeline config file. For example,
@@ -689,6 +692,8 @@ given the following directory structure and file contents:
                  print("Called my_callback_instance_method")
 
 
+         # my_callback_obj has to be visible from my_callback.py's global scope
+         # to enable access to my_callback_instance_method()
          my_callback_obj = MyCallbackClass()
 
 

--- a/peekingduck/configs/augment/brightness.yml
+++ b/peekingduck/configs/augment/brightness.yml
@@ -1,4 +1,5 @@
 input: ["img"]
 output: ["img"]
+callbacks: {}
 
 beta: 0

--- a/peekingduck/configs/augment/contrast.yml
+++ b/peekingduck/configs/augment/contrast.yml
@@ -1,4 +1,5 @@
 input: ["img"]
 output: ["img"]
+callbacks: {}
 
 alpha: 1.0

--- a/peekingduck/configs/augment/undistort.yml
+++ b/peekingduck/configs/augment/undistort.yml
@@ -1,6 +1,7 @@
 # Mandatory configs
 input: ["img"]
 output: ["img"]
+callbacks: {}
 
 # Optional configs
 file_path: PeekingDuck/data/camera_calibration_coeffs.yml

--- a/peekingduck/configs/dabble/bbox_count.yml
+++ b/peekingduck/configs/dabble/bbox_count.yml
@@ -1,2 +1,3 @@
 input: ["bboxes"]
 output: ["count"]
+callbacks: {}

--- a/peekingduck/configs/dabble/bbox_to_3d_loc.yml
+++ b/peekingduck/configs/dabble/bbox_to_3d_loc.yml
@@ -1,5 +1,6 @@
 input: ["bboxes"]
 output: ["obj_3D_locs"]
+callbacks: {}
 
 focal_length: 1.14
 height_factor: 2.5

--- a/peekingduck/configs/dabble/bbox_to_btm_midpoint.yml
+++ b/peekingduck/configs/dabble/bbox_to_btm_midpoint.yml
@@ -1,2 +1,3 @@
 input: ["bboxes", "img"]
 output: ["btm_midpoint"]
+callbacks: {}

--- a/peekingduck/configs/dabble/camera_calibration.yml
+++ b/peekingduck/configs/dabble/camera_calibration.yml
@@ -1,6 +1,7 @@
 # Mandatory configs
 input: ["img"]
 output: ["img"]
+callbacks: {}
 
 # Optional configs
 num_corners: [10, 7]

--- a/peekingduck/configs/dabble/check_large_groups.yml
+++ b/peekingduck/configs/dabble/check_large_groups.yml
@@ -1,4 +1,5 @@
 input: ["obj_attrs"]
 output: ["large_groups"]
+callbacks: {}
 
 group_size_threshold: 5

--- a/peekingduck/configs/dabble/check_nearby_objs.yml
+++ b/peekingduck/configs/dabble/check_nearby_objs.yml
@@ -1,5 +1,6 @@
 input: ["obj_3D_locs"]
 output: ["obj_attrs"]
+callbacks: {}
 
 near_threshold: 2.0
 tag_msg: "TOO CLOSE!"

--- a/peekingduck/configs/dabble/fps.yml
+++ b/peekingduck/configs/dabble/fps.yml
@@ -1,6 +1,7 @@
 input: ["pipeline_end"]
 output: ["fps"]
+callbacks: {}
 
-fps_log_display: True   # Boolean to display logging of fps moving average
-fps_log_freq: 100   # Logging frequency of FPS every n frames in cli
-dampen_fps: True   # Returns FPS averaged over last 10 frames if True, instantaneous if False
+fps_log_display: True # Boolean to display logging of fps moving average
+fps_log_freq: 100 # Logging frequency of FPS every n frames in cli
+dampen_fps: True # Returns FPS averaged over last 10 frames if True, instantaneous if False

--- a/peekingduck/configs/dabble/group_nearby_objs.yml
+++ b/peekingduck/configs/dabble/group_nearby_objs.yml
@@ -1,4 +1,5 @@
 input: ["obj_3D_locs"]
 output: ["obj_attrs"]
+callbacks: {}
 
 obj_dist_threshold: 1.5

--- a/peekingduck/configs/dabble/keypoints_to_3d_loc.yml
+++ b/peekingduck/configs/dabble/keypoints_to_3d_loc.yml
@@ -1,5 +1,6 @@
 input: ["keypoints"]
 output: ["obj_3D_locs"]
+callbacks: {}
 
 focal_length: 1.14
 torso_factor: 0.9

--- a/peekingduck/configs/dabble/statistics.yml
+++ b/peekingduck/configs/dabble/statistics.yml
@@ -1,5 +1,6 @@
 input: ["all"]
 output: ["cum_avg", "cum_min", "cum_max"]
+callbacks: {}
 
 identity: null
 length: null

--- a/peekingduck/configs/dabble/tracking.yml
+++ b/peekingduck/configs/dabble/tracking.yml
@@ -1,5 +1,6 @@
 input: ["img", "bboxes"]
 output: ["obj_attrs"]
+callbacks: {}
 
 optional_inputs: ["mot_metadata"]
 

--- a/peekingduck/configs/dabble/zone_count.yml
+++ b/peekingduck/configs/dabble/zone_count.yml
@@ -1,9 +1,11 @@
 input: ["btm_midpoint"]
 output: ["zones", "zone_count"]
+callbacks: {}
 
 resolution: [1280, 720] # Used only in fraction mode
 
-zones: [
-  [[0, 0], [640, 0], [640, 720], [0, 720]],
-  [[0.5, 0], [1, 0], [1, 1], [0.5, 1]]
-]
+zones:
+  [
+    [[0, 0], [640, 0], [640, 720], [0, 720]],
+    [[0.5, 0], [1, 0], [1, 1], [0.5, 1]],
+  ]

--- a/peekingduck/configs/draw/bbox.yml
+++ b/peekingduck/configs/draw/bbox.yml
@@ -1,4 +1,5 @@
 input: ["bboxes", "img", "bbox_labels"]
 output: ["none"]
+callbacks: {}
 
 show_labels: False

--- a/peekingduck/configs/draw/blur_bbox.yml
+++ b/peekingduck/configs/draw/blur_bbox.yml
@@ -1,4 +1,5 @@
 input: ["bboxes", "img"]
 output: ["img"]
+callbacks: {}
 
 blur_kernel_size: 50

--- a/peekingduck/configs/draw/btm_midpoint.yml
+++ b/peekingduck/configs/draw/btm_midpoint.yml
@@ -1,2 +1,3 @@
 input: ["btm_midpoint", "img"]
 output: ["none"]
+callbacks: {}

--- a/peekingduck/configs/draw/group_bbox_and_tag.yml
+++ b/peekingduck/configs/draw/group_bbox_and_tag.yml
@@ -1,4 +1,5 @@
 input: ["img", "bboxes", "obj_attrs", "large_groups"]
 output: ["none"]
+callbacks: {}
 
 tag: "LARGE GROUP!"

--- a/peekingduck/configs/draw/heat_map.yml
+++ b/peekingduck/configs/draw/heat_map.yml
@@ -1,2 +1,3 @@
 input: ["density_map", "img"]
 output: ["img"]
+callbacks: {}

--- a/peekingduck/configs/draw/instance_mask.yml
+++ b/peekingduck/configs/draw/instance_mask.yml
@@ -1,16 +1,15 @@
 input: ["img", "masks", "bbox_labels"]
 output: ["img"]
+callbacks: {}
 
 instance_color_scheme: hue_family
-effect: {
-  contrast: null,
-  brightness: null,
-  gamma_correction: null,
-  blur: null,
-  mosaic: null
-}
+effect:
+  {
+    contrast: null,
+    brightness: null,
+    gamma_correction: null,
+    blur: null,
+    mosaic: null,
+  }
 effect_area: objects
-contours: {
-    show: False,
-    thickness: 2
-}
+contours: { show: False, thickness: 2 }

--- a/peekingduck/configs/draw/legend.yml
+++ b/peekingduck/configs/draw/legend.yml
@@ -1,11 +1,8 @@
 input: ["all"]
 output: ["img"]
-
+callbacks: {}
 
 box_opacity: 0.3
-font: {
-  size: 0.7,
-  thickness: 2
-}
+font: { size: 0.7, thickness: 2 }
 position: "bottom"
 show: []

--- a/peekingduck/configs/draw/mosaic_bbox.yml
+++ b/peekingduck/configs/draw/mosaic_bbox.yml
@@ -1,4 +1,5 @@
 input: ["bboxes", "img"]
 output: ["img"]
+callbacks: {}
 
 mosaic_level: 7

--- a/peekingduck/configs/draw/poses.yml
+++ b/peekingduck/configs/draw/poses.yml
@@ -1,5 +1,6 @@
 input: ["keypoints", "keypoint_scores", "keypoint_conns", "img"]
 output: ["none"]
+callbacks: {}
 
 keypoint_dot_color: tomato # [77, 103, 255]
 keypoint_connect_color: champagne # [156, 223, 244]

--- a/peekingduck/configs/draw/tag.yml
+++ b/peekingduck/configs/draw/tag.yml
@@ -1,5 +1,6 @@
 input: ["bboxes", "obj_attrs", "img"]
 output: ["none"]
+callbacks: {}
 
 show: []
 tag_color: [77, 103, 255]

--- a/peekingduck/configs/draw/zones.yml
+++ b/peekingduck/configs/draw/zones.yml
@@ -1,2 +1,3 @@
 input: ["zones", "img"]
 output: ["none"]
+callbacks: {}

--- a/peekingduck/configs/input/visual.yml
+++ b/peekingduck/configs/input/visual.yml
@@ -1,14 +1,11 @@
 input: ["none"]
 output: ["img", "filename", "pipeline_end", "saved_video_fps"]
+callbacks: {}
 
 filename: video.mp4
 frames_log_freq: 100
 mirror_image: False
-resize: {
-            do_resizing: False,
-            width: 1280,
-            height: 720
-        }
+resize: { do_resizing: False, width: 1280, height: 720 }
 saved_video_fps: 10
 source: https://storage.googleapis.com/peekingduck/videos/wave.mp4
 threading: False

--- a/peekingduck/configs/model/csrnet.yml
+++ b/peekingduck/configs/model/csrnet.yml
@@ -1,5 +1,6 @@
 input: ["img"]
 output: ["density_map", "count"]
+callbacks: {}
 
 weights_parent_dir: null
 weights:

--- a/peekingduck/configs/model/efficientdet.yml
+++ b/peekingduck/configs/model/efficientdet.yml
@@ -1,5 +1,6 @@
 input: ["img"]
 output: ["bboxes", "bbox_labels", "bbox_scores"]
+callbacks: {}
 
 weights_parent_dir: null
 weights:

--- a/peekingduck/configs/model/fairmot.yml
+++ b/peekingduck/configs/model/fairmot.yml
@@ -1,5 +1,6 @@
 input: ["img"]
 output: ["bboxes", "bbox_labels", "bbox_scores", "obj_attrs"]
+callbacks: {}
 
 optional_inputs: ["mot_metadata"]
 

--- a/peekingduck/configs/model/hrnet.yml
+++ b/peekingduck/configs/model/hrnet.yml
@@ -1,5 +1,6 @@
 input: ["img", "bboxes"]
 output: ["keypoints", "keypoint_scores", "keypoint_conns"]
+callbacks: {}
 
 weights_parent_dir: null
 weights:

--- a/peekingduck/configs/model/huggingface_hub.yml
+++ b/peekingduck/configs/model/huggingface_hub.yml
@@ -4,6 +4,7 @@ output:
     instance_segmentation: ["bboxes", "bbox_labels", "bbox_scores", "masks"],
     object_detection: ["bboxes", "bbox_labels", "bbox_scores"],
   }
+callbacks: {}
 
 weights_parent_dir: null
 weights: { default: { model_subdir: huggingface } }

--- a/peekingduck/configs/model/jde.yml
+++ b/peekingduck/configs/model/jde.yml
@@ -1,5 +1,6 @@
 input: ["img"]
 output: ["bboxes", "bbox_labels", "bbox_scores", "obj_attrs"]
+callbacks: {}
 
 optional_inputs: ["mot_metadata"]
 

--- a/peekingduck/configs/model/mask_rcnn.yml
+++ b/peekingduck/configs/model/mask_rcnn.yml
@@ -1,5 +1,6 @@
 input: ["img"]
 output: ["bboxes", "bbox_labels", "bbox_scores", "masks"]
+callbacks: {}
 
 weights_parent_dir: null
 weights:

--- a/peekingduck/configs/model/movenet.yml
+++ b/peekingduck/configs/model/movenet.yml
@@ -1,6 +1,7 @@
 input: ["img"]
 output:
   ["bboxes", "keypoints", "keypoint_scores", "keypoint_conns", "bbox_labels"]
+callbacks: {}
 
 weights_parent_dir: null
 weights:

--- a/peekingduck/configs/model/mtcnn.yml
+++ b/peekingduck/configs/model/mtcnn.yml
@@ -1,5 +1,6 @@
 input: ["img"]
 output: ["bboxes", "bbox_labels", "bbox_scores"]
+callbacks: {}
 
 weights_parent_dir: null
 weights:

--- a/peekingduck/configs/model/posenet.yml
+++ b/peekingduck/configs/model/posenet.yml
@@ -1,6 +1,7 @@
 input: ["img"]
 output:
   ["bboxes", "keypoints", "keypoint_scores", "keypoint_conns", "bbox_labels"]
+callbacks: {}
 
 weights_parent_dir: null
 weights:

--- a/peekingduck/configs/model/yolact_edge.yml
+++ b/peekingduck/configs/model/yolact_edge.yml
@@ -1,5 +1,6 @@
 input: ["img"]
 output: ["bboxes", "bbox_labels", "bbox_scores", "masks"]
+callbacks: {}
 
 weights_parent_dir: null
 weights:
@@ -7,28 +8,23 @@ weights:
     pytorch:
       {
         model_subdir: yolact_edge,
-        blob_file: 
-        { 
-          r50-fpn: yolact-edge-r50-fpn-coco.zip,
-          r101-fpn: yolact-edge-r101-fpn-coco.zip,
-          mobilenetv2: yolact-edge-mobilenetv2-coco.zip
-        },
+        blob_file:
+          {
+            r50-fpn: yolact-edge-r50-fpn-coco.zip,
+            r101-fpn: yolact-edge-r101-fpn-coco.zip,
+            mobilenetv2: yolact-edge-mobilenetv2-coco.zip,
+          },
         classes_file: coco.names,
-        model_file: 
-        { 
-          r50-fpn: yolact-edge-r50-fpn-coco.pth,
-          r101-fpn: yolact-edge-r101-fpn-coco.pth,
-          mobilenetv2: yolact-edge-mobilenetv2-coco.pth
-        },
+        model_file:
+          {
+            r50-fpn: yolact-edge-r50-fpn-coco.pth,
+            r101-fpn: yolact-edge-r101-fpn-coco.pth,
+            mobilenetv2: yolact-edge-mobilenetv2-coco.pth,
+          },
       },
   }
 
-model_size:
-  {
-    r50-fpn: {},
-    r101-fpn: {},
-    mobilenetv2: {}
-  }
+model_size: { r50-fpn: {}, r101-fpn: {}, mobilenetv2: {} }
 num_classes: 80
 
 model_format: pytorch

--- a/peekingduck/configs/model/yolo.yml
+++ b/peekingduck/configs/model/yolo.yml
@@ -1,5 +1,6 @@
 input: ["img"]
 output: ["bboxes", "bbox_labels", "bbox_scores"]
+callbacks: {}
 
 weights_parent_dir: null
 weights:

--- a/peekingduck/configs/model/yolo_face.yml
+++ b/peekingduck/configs/model/yolo_face.yml
@@ -1,5 +1,6 @@
 input: ["img"]
 output: ["bboxes", "bbox_labels", "bbox_scores"]
+callbacks: {}
 
 weights_parent_dir: null
 weights:

--- a/peekingduck/configs/model/yolo_license_plate.yml
+++ b/peekingduck/configs/model/yolo_license_plate.yml
@@ -1,5 +1,6 @@
 input: ["img"]
 output: ["bboxes", "bbox_labels", "bbox_scores"]
+callbacks: {}
 
 weights_parent_dir: null
 weights:

--- a/peekingduck/configs/model/yolox.yml
+++ b/peekingduck/configs/model/yolox.yml
@@ -1,5 +1,6 @@
 input: ["img"]
 output: ["bboxes", "bbox_labels", "bbox_scores"]
+callbacks: {}
 
 weights_parent_dir: null
 weights:

--- a/peekingduck/configs/node_template.yml
+++ b/peekingduck/configs/node_template.yml
@@ -7,6 +7,7 @@ input: ["bboxes", "bbox_labels"]
 # Output `obj_attrs` for visualization with `draw.tag` node and `custom_key` for
 # use with other custom nodes. Replace as required.
 output: ["obj_attrs", "custom_key"]
+callbacks: {}
 
 # Optional configs depending on node
 threshold: 0.5 # example

--- a/peekingduck/configs/output/csv_writer.yml
+++ b/peekingduck/configs/output/csv_writer.yml
@@ -1,5 +1,6 @@
 input: ["all"]
 output: ["none"]
+callbacks: {}
 
 stats_to_track: ["keypoints", "bboxes", "bbox_labels"]
 file_path: "PeekingDuck/data/stats.csv"

--- a/peekingduck/configs/output/media_writer.yml
+++ b/peekingduck/configs/output/media_writer.yml
@@ -1,4 +1,5 @@
 input: ["img", "filename", "saved_video_fps", "pipeline_end"]
 output: ["none"]
+callbacks: {}
 
 output_dir: "PeekingDuck/data/output"

--- a/peekingduck/configs/output/screen.yml
+++ b/peekingduck/configs/output/screen.yml
@@ -1,13 +1,7 @@
 input: ["img", "filename"]
 output: ["pipeline_end"]
+callbacks: {}
 
 window_name: "PeekingDuck"
-window_size: {
-    do_resizing: False,
-    width: 1280,
-    height: 720 
-}
-window_loc: {
-    x: 0,
-    y: 0
-}
+window_size: { do_resizing: False, width: 1280, height: 720 }
+window_loc: { x: 0, y: 0 }

--- a/peekingduck/nodes/abstract_node.py
+++ b/peekingduck/nodes/abstract_node.py
@@ -63,7 +63,10 @@ class AbstractNode(ABC):
         # update the node
         self.config_loader = ConfigLoader(pkd_base_dir)
         self.load_node_config(config, kwargs)  # type: ignore
-        self.callback_list = CallbackList.from_dict(self.callbacks)
+        try:
+            self.callback_list = CallbackList.from_dict(self.callbacks)
+        except AttributeError:
+            self.callback_list = CallbackList()
 
         self._change_class_name_to_id()
 

--- a/peekingduck/nodes/abstract_node.py
+++ b/peekingduck/nodes/abstract_node.py
@@ -67,15 +67,7 @@ class AbstractNode(metaclass=ABCMeta):
         self.config_loader = ConfigLoader(pkd_base_dir)
         self.load_node_config(config, kwargs)  # type: ignore
 
-        # For object detection nodes, convert class names to class ids, if any
-        if self.node_name in ["model.yolo", "model.efficientdet", "model.yolox"]:
-            key = "detect" if hasattr(self, "detect") else "detect_ids"
-            current_ids = self.config[key]
-            _, updated_ids = obj_det_change_class_name_to_id(
-                self.node_name, key, current_ids
-            )
-            # replace "detect_ids" with new "detect"
-            self.config["detect"] = updated_ids
+        self._change_class_name_to_id()
 
     @classmethod
     def __subclasshook__(cls, subclass: Any) -> bool:
@@ -174,3 +166,14 @@ class AbstractNode(metaclass=ABCMeta):
     def _get_config_types(self) -> Dict[str, Any]:  # pylint: disable=no-self-use
         """Returns dictionary mapping the node's config keys to respective types."""
         return {}
+
+    def _change_class_name_to_id(self) -> None:
+        """Convert class names to class IDs for object detection nodes, if any"""
+        if self.node_name in ["model.yolo", "model.efficientdet", "model.yolox"]:
+            key = "detect" if hasattr(self, "detect") else "detect_ids"
+            current_ids = self.config[key]
+            _, updated_ids = obj_det_change_class_name_to_id(
+                self.node_name, key, current_ids
+            )
+            # replace "detect_ids" with new "detect"
+            self.config["detect"] = updated_ids

--- a/peekingduck/nodes/abstract_node.py
+++ b/peekingduck/nodes/abstract_node.py
@@ -123,6 +123,15 @@ class AbstractNode(ABC):
         NOTE: To be overridden by subclass if required.
         """
 
+    def _change_class_name_to_id(self) -> None:
+        """Convert class names to class IDs for object detection nodes, if any"""
+        if self.node_name in ["model.yolo", "model.efficientdet", "model.yolox"]:
+            key = "detect" if hasattr(self, "detect") else "detect_ids"
+            current_ids = self.config[key]
+            updated_ids = obj_det_change_class_name_to_id(self.node_name, current_ids)
+            # replace "detect_ids" with new "detect"
+            self.config["detect"] = updated_ids
+
     def _check_type(
         self, config: Dict[str, Any], config_types: Dict[str, Any], parent: str = ""
     ) -> None:
@@ -162,14 +171,3 @@ class AbstractNode(ABC):
     def _get_config_types(self) -> Dict[str, Any]:  # pylint: disable=no-self-use
         """Returns dictionary mapping the node's config keys to respective types."""
         return {}
-
-    def _change_class_name_to_id(self) -> None:
-        """Convert class names to class IDs for object detection nodes, if any"""
-        if self.node_name in ["model.yolo", "model.efficientdet", "model.yolox"]:
-            key = "detect" if hasattr(self, "detect") else "detect_ids"
-            current_ids = self.config[key]
-            _, updated_ids = obj_det_change_class_name_to_id(
-                self.node_name, key, current_ids
-            )
-            # replace "detect_ids" with new "detect"
-            self.config["detect"] = updated_ids

--- a/peekingduck/nodes/abstract_node.py
+++ b/peekingduck/nodes/abstract_node.py
@@ -18,9 +18,9 @@ Abstract Node class for all nodes.
 
 import collections
 import logging
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Union
 
 from typeguard import check_type
 
@@ -28,7 +28,7 @@ from peekingduck.config_loader import ConfigLoader
 from peekingduck.utils.detect_id_mapper import obj_det_change_class_name_to_id
 
 
-class AbstractNode(metaclass=ABCMeta):
+class AbstractNode(ABC):
     """Abstract Node class for inheritance by nodes.
 
     Defines default attributes and methods of a node.
@@ -37,22 +37,18 @@ class AbstractNode(metaclass=ABCMeta):
         config (:obj:`Dict[str, Any]` | :obj:`None`): Node configuration.
         node_path (:obj:`str`): Period-separated (``.``) relative path to the
             node from the ``peekingduck`` directory. **Default: ""**.
-        pkd_base_dir (:obj:`pathlib.Path` | :obj:`None`): Path to
-            ``peekingduck`` directory.
+        pkd_base_dir (:obj:`pathlib.Path`): Path to ``peekingduck`` directory.
     """
 
     def __init__(
         self,
         config: Dict[str, Any] = None,
         node_path: str = "",
-        pkd_base_dir: Optional[Path] = None,
+        pkd_base_dir: Path = Path(__file__).resolve().parents[1],
         **kwargs: Any,
     ) -> None:
         self._name = node_path
         self.logger = logging.getLogger(self._name)
-
-        if not pkd_base_dir:
-            pkd_base_dir = Path(__file__).resolve().parents[1]
 
         self.node_name = ".".join(node_path.split(".")[-2:])
 

--- a/peekingduck/nodes/abstract_node.py
+++ b/peekingduck/nodes/abstract_node.py
@@ -161,7 +161,7 @@ class AbstractNode(ABC):
         """
         if dict_update:
             for key, value in dict_update.items():
-                if isinstance(value, collections.abc.Mapping):
+                if isinstance(value, collections.abc.Mapping) and key != "callbacks":
                     dict_orig[key] = self._edit_config(dict_orig.get(key, {}), value)
                 elif key not in dict_orig:
                     self.logger.warning(

--- a/peekingduck/nodes/abstract_node.py
+++ b/peekingduck/nodes/abstract_node.py
@@ -16,7 +16,7 @@
 Abstract Node class for all nodes.
 """
 
-import collections
+import collections.abc
 import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -25,6 +25,7 @@ from typing import Any, Dict, List, Union
 from typeguard import check_type
 
 from peekingduck.config_loader import ConfigLoader
+from peekingduck.nodes.callback_list import CallbackList
 from peekingduck.utils.detect_id_mapper import obj_det_change_class_name_to_id
 
 
@@ -62,6 +63,7 @@ class AbstractNode(ABC):
         # update the node
         self.config_loader = ConfigLoader(pkd_base_dir)
         self.load_node_config(config, kwargs)  # type: ignore
+        self.callback_list = CallbackList.from_dict(self.callbacks)
 
         self._change_class_name_to_id()
 

--- a/peekingduck/nodes/abstract_node.py
+++ b/peekingduck/nodes/abstract_node.py
@@ -78,19 +78,8 @@ class AbstractNode(metaclass=ABCMeta):
             self.config["detect"] = updated_ids
 
     @classmethod
-    def __subclasshook__(cls: Any, subclass: Any) -> bool:
+    def __subclasshook__(cls, subclass: Any) -> bool:
         return hasattr(subclass, "run") and callable(subclass.run)
-
-    @abstractmethod
-    def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
-        """abstract method needed for running node"""
-        raise NotImplementedError("This method needs to be implemented")
-
-    # pylint: disable=R0201, W0107
-    def release_resources(self) -> None:
-        """To gracefully release any acquired system resources, e.g. webcam
-        NOTE: To be overridden by subclass if required"""
-        pass
 
     @property
     def inputs(self) -> List[str]:
@@ -106,6 +95,10 @@ class AbstractNode(metaclass=ABCMeta):
     def name(self) -> str:
         """Node name."""
         return self._name
+
+    @abstractmethod
+    def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
+        """Abstract method needed for running node."""
 
     def load_node_config(
         self, config: Dict[str, Any], kwargs_config: Dict[str, Any]
@@ -136,6 +129,11 @@ class AbstractNode(metaclass=ABCMeta):
         # sets class attributes
         for key in self.config:
             setattr(self, key, self.config[key])
+
+    def release_resources(self) -> None:
+        """To gracefully release any acquired system resources, e.g. webcam
+        NOTE: To be overridden by subclass if required.
+        """
 
     def _check_type(
         self, config: Dict[str, Any], config_types: Dict[str, Any], parent: str = ""
@@ -173,6 +171,6 @@ class AbstractNode(metaclass=ABCMeta):
                     )
         return dict_orig
 
-    def _get_config_types(self) -> Dict[str, Any]:
+    def _get_config_types(self) -> Dict[str, Any]:  # pylint: disable=no-self-use
         """Returns dictionary mapping the node's config keys to respective types."""
         return {}

--- a/peekingduck/nodes/abstract_node.py
+++ b/peekingduck/nodes/abstract_node.py
@@ -63,9 +63,10 @@ class AbstractNode(ABC):
         # update the node
         self.config_loader = ConfigLoader(pkd_base_dir)
         self.load_node_config(config, kwargs)  # type: ignore
-        try:
+
+        if hasattr(self, "callbacks"):
             self.callback_list = CallbackList.from_dict(self.callbacks)
-        except AttributeError:
+        else:
             self.callback_list = CallbackList()
 
         self._change_class_name_to_id()

--- a/peekingduck/nodes/callback_list.py
+++ b/peekingduck/nodes/callback_list.py
@@ -138,7 +138,7 @@ def import_module_from_file_location(module_name: str, location: Path) -> Module
 
     Args:
         module_name (str): Name of module, should be the same as the name of
-            the Python script file.
+            the Python script file and its subdirectory relative to `callbacks`.
         location (Path): The directory where the Python script file containing
             the module can be found.
 
@@ -150,7 +150,9 @@ def import_module_from_file_location(module_name: str, location: Path) -> Module
         be used.
     """
     spec = importlib.util.spec_from_file_location(
-        module_name, location / f"{module_name}.py"
+        #  module_name, location / f"{module_name}.py"
+        module_name,
+        location.joinpath(*module_name.split(".")).with_suffix(".py"),
     )
     # use default loader
     assert spec is not None and spec.loader is not None

--- a/peekingduck/nodes/callback_list.py
+++ b/peekingduck/nodes/callback_list.py
@@ -84,7 +84,7 @@ class CallbackList:
         Args:
             callback_dict (Dict[str, List[str]]): A dictionary defined in the
                 pipeline config file. Maps `event_type` to a list of callback
-                definitions. Each callback defintion should contain:
+                definition. Each callback defintion should contain:
                     <module>[.<submodule>]*[::<callback class>]::<callback function>
                 The callback modules are expected to be found in the
                 "callbacks" directory in the same location as the pipeline
@@ -133,7 +133,7 @@ def chain_getattr(obj: object, names: List[str], *args: Any) -> Any:
 
 
 def import_module_from_file_location(module_name: str, location: Path) -> ModuleType:
-    """Imports module from the specified location without haivng to modify
+    """Imports module from the specified location without having to modify
     `sys.path`.
 
     Args:

--- a/peekingduck/nodes/callback_list.py
+++ b/peekingduck/nodes/callback_list.py
@@ -1,0 +1,95 @@
+# Copyright 2022 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Container for callbacks which are called at certain points in the
+pipeline.
+"""
+
+import importlib
+from typing import Any, Callable, Dict, List
+
+
+class CallbackList:
+    """Container for callback functions."""
+
+    def __init__(self) -> None:
+        self.callbacks: Dict[str, List[Callable]] = {
+            "run_begin": [],
+            "run_end": [],
+        }
+
+    def append(self, event_type: str, callback: Callable) -> None:
+        """Adds a callback to the specified `event_type`.
+
+        Args:
+            event_type (str): Determines the point in the run loop at which the
+                callback is called.
+            callback (Callable): A function which can take in a dictionary as
+                an argument.
+        """
+        self.callbacks[event_type].append(callback)
+
+    def on_run_begin(self, pipeline_data: Dict[str, Any]) -> None:
+        """Triggers all callbacks set to run at the `run_begin` event.
+
+        Args:
+            pipeline_data (Dict[str, Any]): The current pipeline data.
+        """
+        self._on_event("run_begin", pipeline_data)
+
+    def on_run_end(self, pipeline_data: Dict[str, Any]) -> None:
+        """Triggers all callbacks set to run at the `run_end` event.
+
+        Args:
+            pipeline_data (Dict[str, Any]): The current pipeline data.
+        """
+        self._on_event("run_end", pipeline_data)
+
+    def _on_event(self, event_type: str, pipeline_data: Dict[str, Any]) -> None:
+        """Triggers all callbacks based on the specified event.
+
+        Args:
+            event_type (str): The specified event.
+            pipeline_data (Dict[str, Any]): The current pipeline data.
+        """
+        for callback in self.callbacks[event_type]:
+            callback(pipeline_data)
+
+    @classmethod
+    def from_dict(cls, callback_dict: Dict[str, List[str]]) -> "CallbackList":
+        """Constructs a `CallbackList` object populated with callbacks from
+        `callback_dict`.
+
+        Args:
+            callback_dict (Dict[str, List[str]]): A dictionary defined in the
+                pipeline config file. Maps `event_type` to a list of callback
+                definitions. Each callback defintion should contain:
+                    <module name>[.<submodule name>]*.<callback function name>
+                The callback modules are expected to be found in the
+                "callbacks" directory in the same location as the pipeline
+                config file.
+        """
+        callback_list = cls()
+        base_module = "callbacks"
+        for event_type, callback_names in callback_dict.items():
+            for callback_name in callback_names:
+                module_part, *callback_parts = callback_name.split("::")
+                module = importlib.import_module(f"{base_module}.{module_part}")
+                callback = lambda *args: None
+                for part in callback_parts:
+                    callback = getattr(module, part)
+                callback_list.append(event_type, callback)
+
+        return callback_list

--- a/peekingduck/nodes/callback_list.py
+++ b/peekingduck/nodes/callback_list.py
@@ -150,9 +150,7 @@ def import_module_from_file_location(module_name: str, location: Path) -> Module
         be used.
     """
     spec = importlib.util.spec_from_file_location(
-        #  module_name, location / f"{module_name}.py"
-        module_name,
-        location.joinpath(*module_name.split(".")).with_suffix(".py"),
+        module_name, location.joinpath(*module_name.split(".")).with_suffix(".py")
     )
     # use default loader
     assert spec is not None and spec.loader is not None

--- a/peekingduck/nodes/callback_list.py
+++ b/peekingduck/nodes/callback_list.py
@@ -84,7 +84,7 @@ class CallbackList:
         Args:
             callback_dict (Dict[str, List[str]]): A dictionary defined in the
                 pipeline config file. Maps `event_type` to a list of callback
-                definition. Each callback defintion should contain:
+                definitions. Each callback definition should contain:
                     <module>[.<submodule>]*[::<callback class>]::<callback function>
                 The callback modules are expected to be found in the
                 "callbacks" directory in the same location as the pipeline

--- a/peekingduck/runner.py
+++ b/peekingduck/runner.py
@@ -124,8 +124,10 @@ class Runner:
                         if key in self.pipeline.data:
                             inputs[key] = self.pipeline.data[key]
 
+                node.callback_list.on_run_begin(self.pipeline.data)
                 outputs = node.run(inputs)
                 self.pipeline.data.update(outputs)
+                node.callback_list.on_run_end(self.pipeline.data)
                 if num_iter == 0:
                     node_end_time = perf_counter()
                     self.logger.debug(

--- a/peekingduck/utils/detect_id_mapper.py
+++ b/peekingduck/utils/detect_id_mapper.py
@@ -81,7 +81,7 @@ def obj_det_change_class_name_to_id(node_name: str, value: List[Any]) -> List[in
                            If class names, convert to object IDs.
 
     Returns:
-        Tuple[str, List[int]]: "detect", list of sorted object IDs.
+        List[int]: List of sorted object IDs.
     """
     class_id_map = obj_det_load_class_id_mapping(node_name)
 

--- a/peekingduck/utils/detect_id_mapper.py
+++ b/peekingduck/utils/detect_id_mapper.py
@@ -16,7 +16,7 @@
 
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
 
 import yaml
 
@@ -68,9 +68,7 @@ def obj_det_load_class_id_mapping(node_name: str) -> Dict[str, int]:
     return class_id_map
 
 
-def obj_det_change_class_name_to_id(
-    node_name: str, key: str, value: List[Any]
-) -> Tuple[str, List[int]]:
+def obj_det_change_class_name_to_id(node_name: str, value: List[Any]) -> List[int]:
     """Process object detection model node's detect key and check for
     any class names to be converted to object IDs.
     E.g. person to 0, car to 2
@@ -78,7 +76,6 @@ def obj_det_change_class_name_to_id(
     Args:
         node_name (str): to determine which object detection model is being used
                          because different models can use different object IDs.
-        key (str): expected to be "detect"; error otherwise.
         value (List[Any]): list of class names or object IDs for detection.
                            If object IDs, do nothing.
                            If class names, convert to object IDs.
@@ -111,4 +108,4 @@ def obj_det_change_class_name_to_id(
         x if isinstance(x, int) else class_id_map.get(x, 0) for x in value_lc
     }
     obj_ids_sorted_list = sorted(list(obj_ids_set))
-    return key, obj_ids_sorted_list
+    return obj_ids_sorted_list

--- a/tests/nodes/callback_list/test_callback_list.py
+++ b/tests/nodes/callback_list/test_callback_list.py
@@ -1,0 +1,83 @@
+# Copyright 2022 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import peekingduck.pipeline.dabble.fps as pkd_fps
+import peekingduck.pipeline.input.visual as pkd_visual
+from peekingduck.pipeline.callback_list import CallbackList
+from peekingduck.runner import Runner
+
+SUPPORTED_EVENTS = ["run_begin", "run_end"]
+
+
+@pytest.fixture(name="empty_callback_list")
+def fixture_empty_callback_list():
+    return CallbackList()
+
+
+class CounterCallback:
+    def __init__(self):
+        self.count = 0
+
+    def callback(self, data_pool):
+        self.count += 1
+
+
+@pytest.mark.usefixtures("tmp_dir")
+class TestCallbackList:
+    def test_init_creates_empty_list_for_supported_events(self):
+        callback_list = CallbackList()
+
+        for event_type in SUPPORTED_EVENTS:
+            assert event_type in callback_list.callbacks
+            assert callback_list.callbacks[event_type] == []
+
+        assert callback_list.EVENT_TYPES == SUPPORTED_EVENTS
+
+    @pytest.mark.parametrize("event_type", SUPPORTED_EVENTS)
+    def test_append_to_the_list_mapped_to_event_type(
+        self, empty_callback_list, event_type
+    ):
+        callback = lambda data_pool: None
+
+        empty_callback_list.append(event_type, callback)
+
+        assert empty_callback_list.callbacks[event_type][-1] == callback
+        for event in SUPPORTED_EVENTS:
+            if event != event_type:
+                assert empty_callback_list.callbacks[event] == []
+
+    @pytest.mark.parametrize("event_type", SUPPORTED_EVENTS)
+    def test_run_event_is_triggered_once_per_node_run(
+        self, create_input_video, event_type
+    ):
+        """Checks that callback events such as on_run_begin and on_run_end are
+        triggered once per node per run iteration. CounterCallback tracks the
+        number of times it is called internally.
+
+        The count is equal to num_iter * num_nodes
+        """
+        num_iter = 5
+        _ = create_input_video("video1.avi", fps=10, size=(600, 800, 3), num_frames=30)
+        cb_obj = CounterCallback()
+        visual_node = pkd_visual.Node(source="video1.avi")
+        fps_node = pkd_fps.Node()
+        visual_node.callback_list.append(event_type, cb_obj.callback)
+        fps_node.callback_list.append(event_type, cb_obj.callback)
+        runner = Runner(num_iter=num_iter, nodes=[visual_node, fps_node])
+
+        runner.run()
+
+        assert cb_obj.count == num_iter * 2

--- a/tests/nodes/callback_list/test_load_callbacks_config.py
+++ b/tests/nodes/callback_list/test_load_callbacks_config.py
@@ -1,0 +1,110 @@
+# Copyright 2022 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from peekingduck.nodes.callback_list import CallbackList
+from peekingduck.runner import Runner
+
+SUPPORTED_EVENTS = ["run_begin", "run_end"]
+
+
+@pytest.fixture(name="empty_callback_list")
+def fixture_empty_callback_list():
+    return CallbackList()
+
+
+@pytest.fixture(name="callback_file")
+def fixture_callback_file():
+    callback_dir = Path.cwd() / "callbacks"
+    callback_dir.mkdir()
+    with open(callback_dir / "my_callback.py", "w") as outfile:
+        outfile.write(
+            textwrap.dedent(
+                """
+                def callback_func(data_pool):
+                    raise ValueError("Function")
+                """
+            )
+        )
+    yield
+
+
+@pytest.fixture(name="pipeline_file")
+def fixture_pipeline_file():
+    pipeline_path = Path.cwd() / "pipeline_config.yml"
+    with open(pipeline_path, "w") as outfile:
+        outfile.write(
+            textwrap.dedent(
+                """
+                nodes:
+                - input.visual:
+                    source: video1.avi
+                    callbacks:
+                      run_begin: [my_callback::callback_func]
+                """
+            )
+        )
+    yield pipeline_path
+
+
+@pytest.fixture(name="default_pipeline_file")
+def fixture_default_pipeline_file():
+    pipeline_path = Path.cwd() / "pipeline_config.yml"
+    with open(pipeline_path, "w") as outfile:
+        outfile.write(
+            textwrap.dedent(
+                """
+                nodes:
+                - input.visual:
+                    source: video1.avi
+                """
+            )
+        )
+    yield pipeline_path
+
+
+@pytest.mark.usefixtures("tmp_dir", "callback_file")
+class TestLoadCallbacksConfig:
+    def test_declarative_loader_parses_callbacks_in_pipeline_config(
+        self, create_input_video, pipeline_file
+    ):
+        _ = create_input_video("video1.avi", fps=10, size=(600, 800, 3), num_frames=30)
+        runner = Runner(
+            pipeline_path=pipeline_file,
+            config_updates_cli="None",
+            custom_nodes_parent_subdir="src",
+        )
+        with pytest.raises(ValueError) as excinfo:
+            runner.run()
+        assert "Function" in str(excinfo.value)
+
+    def test_declarative_loader_parses_callbacks_in_cli_config(
+        self, create_input_video, default_pipeline_file
+    ):
+        _ = create_input_video("video1.avi", fps=10, size=(600, 800, 3), num_frames=30)
+        runner = Runner(
+            pipeline_path=default_pipeline_file,
+            config_updates_cli=(
+                "{'input.visual': {'callbacks': "
+                "{'run_begin': ['my_callback::callback_func']}}}"
+            ),
+            custom_nodes_parent_subdir="src",
+        )
+        with pytest.raises(ValueError) as excinfo:
+            runner.run()
+        assert "Function" in str(excinfo.value)

--- a/tests/nodes/callback_list/test_load_callbacks_config.py
+++ b/tests/nodes/callback_list/test_load_callbacks_config.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import pytest
 
+import peekingduck.nodes.input.visual as pkd_visual
 from peekingduck.nodes.callback_list import CallbackList
 from peekingduck.runner import Runner
 
@@ -105,6 +106,19 @@ class TestLoadCallbacksConfig:
             ),
             custom_nodes_parent_subdir="src",
         )
+        with pytest.raises(ValueError) as excinfo:
+            runner.run()
+        assert "Function" in str(excinfo.value)
+
+    def test_declarative_loader_parses_callbacks_config_in_node_constructor(
+        self, create_input_video
+    ):
+        _ = create_input_video("video1.avi", fps=10, size=(600, 800, 3), num_frames=30)
+        visual_node = pkd_visual.Node(
+            source="video1.avi", callbacks={"run_begin": ["my_callback::callback_func"]}
+        )
+        runner = Runner(nodes=[visual_node])
+
         with pytest.raises(ValueError) as excinfo:
             runner.run()
         assert "Function" in str(excinfo.value)

--- a/tests/nodes/test_node.py
+++ b/tests/nodes/test_node.py
@@ -24,10 +24,10 @@ class ConcreteNode(AbstractNode):
     def __init__(self, config={}, **kwargs):
         super().__init__(config=config, node_path="input.visual", **kwargs)
 
-    def run(self, inputs: Dict):
+    def run(self, inputs):
         return {"data1": 1, "data2": 42}
 
-    def _get_config_types(self) -> Dict[str, Any]:
+    def _get_config_types(self):
         """Returns dictionary mapping the node's config keys to respective types."""
         return {
             "buffering": bool,
@@ -54,7 +54,7 @@ class ObjDetNodeEfficientDet(AbstractNode):
         node_name = "model.efficientdet"
         super().__init__(config=config, node_path=node_name, **kwargs)
 
-    def run(self, inputs: Dict):
+    def run(self, inputs):
         return {}
 
 
@@ -63,7 +63,7 @@ class ObjDetNodeYolo(AbstractNode):
         node_name = "model.yolo"
         super().__init__(config=config, node_path=node_name, **kwargs)
 
-    def run(self, inputs: Dict):
+    def run(self, inputs):
         return {}
 
 

--- a/tests/nodes/test_node.py
+++ b/tests/nodes/test_node.py
@@ -129,19 +129,16 @@ class TestNode:
         key = "detect"
         val = ["*"]
         # fmt: off
-        ground_truth = (
-            "detect",
-            [
-                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16,
-                17, 18, 19, 20, 21, 22, 23, 24, 26, 27, 30, 31, 32, 33, 34, 35,
-                36, 37, 38, 39, 40, 41, 42, 43, 45, 46, 47, 48, 49, 50, 51, 52,
-                53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 66, 69, 71, 72,
-                73, 74, 75, 76, 77, 78, 79, 80, 81, 83, 84, 85, 86, 87, 88, 89
-            ]
-        )
+        ground_truth = [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16,
+            17, 18, 19, 20, 21, 22, 23, 24, 26, 27, 30, 31, 32, 33, 34, 35,
+            36, 37, 38, 39, 40, 41, 42, 43, 45, 46, 47, 48, 49, 50, 51, 52,
+            53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 66, 69, 71, 72,
+            73, 74, 75, 76, 77, 78, 79, 80, 81, 83, 84, 85, 86, 87, 88, 89
+        ]
         # fmt: on
 
-        test_res = obj_det_change_class_name_to_id(node_name, key, val)
+        test_res = obj_det_change_class_name_to_id(node_name, val)
         assert test_res == ground_truth
 
     def test_config_loader_obj_det_wildcard_yolo(self):
@@ -150,19 +147,16 @@ class TestNode:
         key = "detect"
         val = ["*"]
         # fmt: off
-        ground_truth = (
-            "detect",
-            [
-                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
-                16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
-                32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
-                48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
-                64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79
-            ]
-        )
+        ground_truth = [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+            16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+            32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+            48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
+            64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79
+        ]
         # fmt: on
 
-        test_res = obj_det_change_class_name_to_id(node_name, key, val)
+        test_res = obj_det_change_class_name_to_id(node_name, val)
         assert test_res == ground_truth
 
     def test_config_loader_change_class_name_to_id_all_text(self):
@@ -170,9 +164,9 @@ class TestNode:
         node_name = "model.yolo"
         key = "detect"
         val = ["person", "car", "BUS", "CELL PHONE", "oven"]
-        ground_truth = ("detect", [0, 2, 5, 67, 69])
+        ground_truth = [0, 2, 5, 67, 69]
 
-        test_res = obj_det_change_class_name_to_id(node_name, key, val)
+        test_res = obj_det_change_class_name_to_id(node_name, val)
         assert test_res == ground_truth
 
     def test_config_loader_change_class_name_to_id_all_int(self):
@@ -180,9 +174,9 @@ class TestNode:
         node_name = "model.yolo"
         key = "detect"
         val = [0, 1, 2, 3, 5]
-        ground_truth = ("detect", [0, 1, 2, 3, 5])
+        ground_truth = [0, 1, 2, 3, 5]
 
-        test_res = obj_det_change_class_name_to_id(node_name, key, val)
+        test_res = obj_det_change_class_name_to_id(node_name, val)
         assert test_res == ground_truth
 
     def test_config_loader_change_class_name_to_id_mix_int_text(self):
@@ -190,9 +184,9 @@ class TestNode:
         node_name = "model.yolo"
         key = "detect"
         val = [4, "bicycle", 10, "LAPTOP", "teddy bear"]
-        ground_truth = ("detect", [1, 4, 10, 63, 77])
+        ground_truth = [1, 4, 10, 63, 77]
 
-        test_res = obj_det_change_class_name_to_id(node_name, key, val)
+        test_res = obj_det_change_class_name_to_id(node_name, val)
         assert test_res == ground_truth
 
     def test_config_loader_change_class_name_to_id_mix_int_text_duplicates(self):
@@ -209,9 +203,9 @@ class TestNode:
             63,
             10,
         ]
-        ground_truth = ("detect", [1, 4, 10, 63, 77])
+        ground_truth = [1, 4, 10, 63, 77]
 
-        test_res = obj_det_change_class_name_to_id(node_name, key, val)
+        test_res = obj_det_change_class_name_to_id(node_name, val)
         assert test_res == ground_truth
 
     def test_config_loader_change_class_name_to_id_mix_int_text_errors(self):
@@ -230,9 +224,9 @@ class TestNode:
             "pokemon",
             "scary monster",
         ]
-        ground_truth = ("detect", [0, 1, 4, 10, 63, 77])
+        ground_truth = [0, 1, 4, 10, 63, 77]
 
-        test_res = obj_det_change_class_name_to_id(node_name, key, val)
+        test_res = obj_det_change_class_name_to_id(node_name, val)
         assert test_res == ground_truth
 
     #


### PR DESCRIPTION
Enables users to attach callback functions to nodes to be run at certain points/events in the pipeline.

**Implemented events**:
- `run_begin`: Before `Node.run()`
- `run_end`: After `Node.run()`

**Supported callback types**:
- Pure function
- Class methods
- Static methods
- Instance methods (require instantiating the object in the callback script)

**UI**:
Users will specify callbacks for the node under the `callbacks` config key. Each callback is specified as:
```
callback definition = module part, "::", callback part
module part         = { subdir name, "." }, script name
callback part       = function
                     | class name, "::", method
                     | instance name, "::", instance method

script name     = ? name of callback Python script ?
subdir name     = ? name of individual subdirectory folders relative to `callbacks` folder ?
class name      = ? name of class which contains the callback methods ?
instance name   = ? name of instantiated object which contains the callback method ?
function        = ? name of callback function ?
method          = ? name of class/static methods ?
instance method = ? name of instance method ?
```

Incorrect callback definitions are skipped with a warning log, program is not halted.

**Implementation detail**:
In `_edit_config()` of both `AbstractNode` and `DeclarativeLoader`, avoid going deeper into nested dictionary if the key is `callbacks`. This allows us to define the callbacks config in PeekingDuck as
```
callbacks: {}
```
and in pipeline config as
```
- node.name:
    callbacks:
      run_begin: ["callback::definition"]
```
This allows us to implement more callback events in the future without have to add the event key to all the config files in PeekingDuck.


**Sample usage**:
Extract [callbacks.zip](https://github.com/aisingapore/PeekingDuck/files/9771643/callbacks.zip) into your project directory. Ensure that the `callbacks` directory is at the same level as `dev_callback.yml`. You should have the following directory layout:
```
project_dir
+-callbacks
| +-cb_dir
| +-my_callbacks.py
| \-sql_callback.py
+-dev_callback.yml
\-...
```

Run `dev_callback.yml` and you should see logging outputs such as
- `called 1` from `callback_1()` in `my_callbacks.py`
- `called z` from `cb_1()` in `cb_dir/mycb.py`
- `Suppressing logging` from `MyCallback.callback_2()` in `my_callbacks.py`
- `Exceed zone limit ...` from `MyCallback.callback_3()` in `my_callbacks.py`
- `Update db with frame_count ...` from `cb_obj.track_count_callback()` in `sql_callback.py`

**Additional changes**:
- Refactored depracation code into separate methods (for ease of removal in the future)
- Removed `key` argument from `obj_det_class_name_to_id()`