### PR TITLE
Fix: add model hub config types

### DIFF
--- a/peekingduck/pipeline/nodes/model/huggingface_hub.py
+++ b/peekingduck/pipeline/nodes/model/huggingface_hub.py
@@ -14,7 +14,7 @@
 
 """Hugging Face Hub models for computer vision tasks."""
 
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional, Union
 
 import cv2
 import numpy as np
@@ -132,3 +132,16 @@ class Node(ThresholdCheckerMixin, AbstractNode):
         """Updates output keys based on the selected ``task``."""
         self.config["output"] = self.config["output"][self.task]
         self.output = self.config["output"]
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        return {
+            "agnostic_nms": bool,
+            "detect": List[Union[int, str]],
+            "iou_threshold": float,
+            "mask_threshold": float,
+            # Allow `None` to trigger listing available model types in error message
+            "model_type": Optional[str],
+            "score_threshold": float,
+            "task": str,
+            "weights_parent_dir": Optional[str],
+        }

--- a/peekingduck/pipeline/nodes/model/mediapipe_hub.py
+++ b/peekingduck/pipeline/nodes/model/mediapipe_hub.py
@@ -91,10 +91,7 @@ class Node(ThresholdCheckerMixin, AbstractNode):
         self.check_valid_choice("task", {"object_detection", "pose_estimation"})
 
         self.model = self.model_constructor[self.config["task"]](self.config)
-        try:
-            self.model.post_init()
-        except AttributeError:
-            pass
+        self.model.post_init()
         self._finalize_output_keys()
 
     def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:

--- a/peekingduck/pipeline/nodes/model/mediapipe_hub.py
+++ b/peekingduck/pipeline/nodes/model/mediapipe_hub.py
@@ -14,7 +14,7 @@
 
 """MediaPipe ML solutions."""
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import cv2
 import numpy as np
@@ -48,7 +48,7 @@ class Node(ThresholdCheckerMixin, AbstractNode):
             Defines the subtask of MediaPipe model. Use the CLI
             command ``peekingduck model-hub mediapipe tasks`` to obtain a list
             of computer vision tasks and their respective subtasks.
-        model_type (:obj:`str`): **Refer to CLI command, default=0**. |br|
+        model_type (:obj:`int`): **Refer to CLI command, default=0**. |br|
             Defines the type of model to be used for the selected subtask. Use
             the CLI command ``peekingduck model-hub mediapipe model-types
             --task '<task>' --subtask '<subtask>'`` to obtain a list of
@@ -135,3 +135,15 @@ class Node(ThresholdCheckerMixin, AbstractNode):
         """Updates output keys based on the selected ``task``."""
         self.config["output"] = self.config["output"][self.task]
         self.output = self.config["output"]
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        return {
+            "task": str,
+            "model_type": int,
+            "score_threshold": float,
+            "smooth_landmarks": bool,
+            "static_image_mode": bool,
+            # Allow `None` to list available subtasks in error message
+            "subtask": Optional[str],
+            "tracking_score_threshold": float,
+        }


### PR DESCRIPTION
- Implement the `_get_config_types()` method for `huggingface_hub.Node` and `mediapipe_hub.Node`.
- `model_types` in huggingface hub and `subtask` in mediapipe hub allow `None` to allow `check_valid_choice()` throw a better error message