### PR TITLE
Fix: yolact edge cudnn import

### DIFF
--- a/peekingduck/pipeline/nodes/model/yolact_edgev1/yolact_edge_files/detector.py
+++ b/peekingduck/pipeline/nodes/model/yolact_edgev1/yolact_edge_files/detector.py
@@ -56,8 +56,8 @@ class Detector:  # pylint: disable=too-many-instance-attributes
         model_file: Dict[str, str],
         input_size: int,
         max_num_detections: int,
-        score_threshold: float,
         iou_threshold: float,
+        score_threshold: float,
     ) -> None:
         self.logger = logging.getLogger(__name__)
         self.has_cuda: bool = torch.cuda.is_available()
@@ -77,8 +77,8 @@ class Detector:  # pylint: disable=too-many-instance-attributes
         self.model_path = model_dir / model_file[self.model_type]
         self.input_size = (input_size, input_size)
         self.max_num_detections = max_num_detections
-        self.score_threshold = score_threshold
         self.iou_threshold = iou_threshold
+        self.score_threshold = score_threshold
 
         self.update_detect_ids(detect_ids)
 

--- a/peekingduck/pipeline/nodes/model/yolact_edgev1/yolact_edge_files/model.py
+++ b/peekingduck/pipeline/nodes/model/yolact_edgev1/yolact_edge_files/model.py
@@ -83,30 +83,26 @@ Modifications include:
 """
 
 import logging
-from math import sqrt
 from itertools import product
+from math import sqrt
 from pathlib import Path
-from typing import Iterable, List, Tuple, Dict, Any, Union, Optional, Callable
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
 
-from peekingduck.pipeline.nodes.model.yolact_edgev1.yolact_edge_files.utils import (
-    make_net,
-    jaccard,
-    decode,
-    make_extra,
-)
 from peekingduck.pipeline.nodes.model.yolact_edgev1.yolact_edge_files.backbone import (
-    ResNetBackbone,
     MobileNetV2Backbone,
+    ResNetBackbone,
 )
-
-if torch.cuda.is_available():
-    torch.cuda.current_device()
-
+from peekingduck.pipeline.nodes.model.yolact_edgev1.yolact_edge_files.utils import (
+    decode,
+    jaccard,
+    make_extra,
+    make_net,
+)
 
 ScriptModuleWrapper = torch.jit.ScriptModule
 

--- a/peekingduck/pipeline/nodes/model/yolact_edgev1/yolact_edge_model.py
+++ b/peekingduck/pipeline/nodes/model/yolact_edgev1/yolact_edge_model.py
@@ -16,6 +16,7 @@
 
 import logging
 from typing import Any, Dict, List, Tuple
+
 import numpy as np
 
 from peekingduck.pipeline.nodes.base import (
@@ -51,8 +52,8 @@ class YolactEdgeModel(ThresholdCheckerMixin, WeightsDownloaderMixin):
             self.weights["model_file"],
             self.config["input_size"],
             self.config["max_num_detections"],
-            self.config["score_threshold"],
             self.config["iou_threshold"],
+            self.config["score_threshold"],
         )
 
     @property


### PR DESCRIPTION
Closes https://github.com/aisingapore/PeekingDuck-Private/issues/94

- Fixes `cudnn` import in yolactedge
- Sets `cudnn` options once in `__init__` (similar to [source repo](https://github.com/haotian-liu/yolact_edge/blob/a9a00281b33b3ac90253a4939773308a8f95e21d/yolact_edge/inference.py#L155))
- Instantiates `FastBaseTransform` as `self._preprocess` once
- Remove unnecesary instance variable (filtered_output) and local variables in `_postprocess()`
- Filter `network_output` by class ID inplace and use that for further processing.