### PR TITLE
Feat: lazy loading

### DIFF
--- a/docs/source/tutorials/05_calling_peekingduck_in_python.rst
+++ b/docs/source/tutorials/05_calling_peekingduck_in_python.rst
@@ -134,12 +134,9 @@ Copy over the following code to ``demo_debug.py``:
       :linenos:
   
       from pathlib import Path
+
+      from peekingduck.pipeline.nodes import dabble, draw, input, model, output
   
-      from peekingduck.pipeline.nodes.dabble import fps
-      from peekingduck.pipeline.nodes.draw import bbox, legend
-      from peekingduck.pipeline.nodes.input import visual
-      from peekingduck.pipeline.nodes.model import yolo
-      from peekingduck.pipeline.nodes.output import media_writer, screen
       from peekingduck.runner import Runner
       from src.custom_nodes.dabble import debug
   
@@ -147,15 +144,15 @@ Copy over the following code to ``demo_debug.py``:
       def main():
           debug_node = debug.Node(pkd_base_dir=Path.cwd() / "src" / "custom_nodes")
       
-          visual_node = visual.Node(source=str(Path.cwd() / "cat_and_computer.mp4"))
-          yolo_node = yolo.Node(detect=["cup", "cat", "laptop", "keyboard", "mouse"])
-          bbox_node = bbox.Node(show_labels=True)
+          visual_node = input.visual.Node(source=str(Path.cwd() / "cat_and_computer.mp4"))
+          yolo_node = model.yolo.Node(detect=["cup", "cat", "laptop", "keyboard", "mouse"])
+          bbox_node = draw.bbox.Node(show_labels=True)
       
-          fps_node = fps.Node()
-          legend_node = legend.Node(show=["fps"])
-          screen_node = screen.Node()
+          fps_node = dabble.fps.Node()
+          legend_node = draw.legend.Node(show=["fps"])
+          screen_node = output.screen.Node()
       
-          media_writer_node = media_writer.Node(output_dir=str(Path.cwd() / "results"))
+          media_writer_node = output.media_writer.Node(output_dir=str(Path.cwd() / "results"))
       
           runner = Runner(
               nodes=[
@@ -393,13 +390,12 @@ Import the Modules
 
 Lines 9 - 10: You can also do::
 
-   from peekingduck.pipeline.nodes.draw import bbox as pkd_bbox
-   from peekingduck.pipeline.nodes.model import yolo_license_plate as pkd_yolo_license_plate
+   from peekingduck.pipeline.nodes import draw, model
     
-   bbox_node = pkd_bbox.Node()
-   yolo_license_plate_node = pkd_yolo_license_plate.Node()
+   bbox_node = draw.bbox.Node()
+   yolo_license_plate_node = model.yolo_license_plate.Node()
 
-to avoid potential name conflicts.
+to isolate the namespace to avoid potential name conflicts.
 
 
 Initialize PeekingDuck Nodes

--- a/notebooks/calling_peekingduck_in_python.ipynb
+++ b/notebooks/calling_peekingduck_in_python.ipynb
@@ -22,13 +22,13 @@
       "source": [
         "## Import the necessary modules\n",
         "\n",
-        "You can also do\n",
+        "You can also import PeekingDuck modules using\n",
         "```\n",
-        "from peekingduck.pipeline.nodes.draw import bbox as pkd_bbox\n",
+        "from peekingduck.pipeline.nodes import draw\n",
         "\n",
-        "bbox_node = pkd_bbox.Node()\n",
+        "bbox_node = draw.bbox.Node()\n",
         "```\n",
-        "to avoid potential name conflicts."
+        "to isolate the namespace to avoid potential conflicts."
       ]
     },
     {
@@ -290,7 +290,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.8.12"
+      "version": "3.8.13"
     },
     "orig_nbformat": 4
   },

--- a/peekingduck/pipeline/nodes/augment/__init__.py
+++ b/peekingduck/pipeline/nodes/augment/__init__.py
@@ -15,3 +15,21 @@
 """
 Performs image processing. This can be done before or after the model.
 """
+
+import sys
+from typing import TYPE_CHECKING
+
+from peekingduck.utils.lazy_module import ImportStructure, _LazyModule
+
+_import_structure: ImportStructure = {
+    "brightness": [],
+    "contrast": [],
+    "undistort": [],
+}
+
+if TYPE_CHECKING:
+    from . import brightness, contrast, undistort
+else:
+    sys.modules[__name__] = _LazyModule(
+        __name__, globals()["__file__"], _import_structure, __spec__
+    )

--- a/peekingduck/pipeline/nodes/dabble/__init__.py
+++ b/peekingduck/pipeline/nodes/dabble/__init__.py
@@ -15,3 +15,43 @@
 """
 Algorithms that perform calculations/heuristics on the outputs of ``model``.
 """
+
+import sys
+from typing import TYPE_CHECKING
+
+from peekingduck.utils.lazy_module import ImportStructure, _LazyModule
+
+_import_structure: ImportStructure = {
+    "bbox_count": [],
+    "bbox_to_3d_loc": [],
+    "bbox_to_btm_midpoint": [],
+    "camera_calibration": [],
+    "check_large_groups": [],
+    "check_nearby_objs": [],
+    "fps": [],
+    "group_nearby_objs": [],
+    "keypoints_to_3d_loc": [],
+    "statistics": [],
+    "tracking": [],
+    "zone_count": [],
+}
+
+if TYPE_CHECKING:
+    from . import (
+        bbox_count,
+        bbox_to_3d_loc,
+        bbox_to_btm_midpoint,
+        camera_calibration,
+        check_large_groups,
+        check_nearby_objs,
+        fps,
+        group_nearby_objs,
+        keypoints_to_3d_loc,
+        statistics,
+        tracking,
+        zone_count,
+    )
+else:
+    sys.modules[__name__] = _LazyModule(
+        __name__, globals()["__file__"], _import_structure, __spec__
+    )

--- a/peekingduck/pipeline/nodes/draw/__init__.py
+++ b/peekingduck/pipeline/nodes/draw/__init__.py
@@ -19,3 +19,41 @@ Draws results/outputs to an image.
     :mod:`draw.image_processor` is deprecated, and replaced by the nodes
     :mod:`augment.brightness` and :mod:`augment.contrast`.
 """
+
+import sys
+from typing import TYPE_CHECKING
+
+from peekingduck.utils.lazy_module import ImportStructure, _LazyModule
+
+_import_structure: ImportStructure = {
+    "bbox": [],
+    "blur_bbox": [],
+    "btm_midpoint": [],
+    "group_bbox_and_tag": [],
+    "heat_map": [],
+    "instance_mask": [],
+    "legend": [],
+    "mosaic_bbox": [],
+    "poses": [],
+    "tag": [],
+    "zones": [],
+}
+
+if TYPE_CHECKING:
+    from . import (
+        bbox,
+        blur_bbox,
+        btm_midpoint,
+        group_bbox_and_tag,
+        heat_map,
+        instance_mask,
+        legend,
+        mosaic_bbox,
+        poses,
+        tag,
+        zones,
+    )
+else:
+    sys.modules[__name__] = _LazyModule(
+        __name__, globals()["__file__"], _import_structure, __spec__
+    )

--- a/peekingduck/pipeline/nodes/input/__init__.py
+++ b/peekingduck/pipeline/nodes/input/__init__.py
@@ -19,3 +19,19 @@ Reads data from a given input.
     :mod:`input.live` and :mod:`input.recorded` are deprecated.
     They have been replaced by the :mod:`input.visual` node.
 """
+
+import sys
+from typing import TYPE_CHECKING
+
+from peekingduck.utils.lazy_module import ImportStructure, _LazyModule
+
+_import_structure: ImportStructure = {
+    "visual": [],
+}
+
+if TYPE_CHECKING:
+    from . import visual
+else:
+    sys.modules[__name__] = _LazyModule(
+        __name__, globals()["__file__"], _import_structure, __spec__
+    )

--- a/peekingduck/pipeline/nodes/model/__init__.py
+++ b/peekingduck/pipeline/nodes/model/__init__.py
@@ -15,3 +15,51 @@
 """
 Deep learning model nodes for computer vision.
 """
+
+import sys
+from typing import TYPE_CHECKING
+
+from peekingduck.utils.lazy_module import ImportStructure, _LazyModule
+
+_import_structure: ImportStructure = {
+    "csrnet": [],
+    "yolo_license_plate": [],
+    "huggingface_hub": [],
+    "posenet": [],
+    "yolo": [],
+    "mediapipe_hub": [],
+    "efficientdet": [],
+    "fairmot": [],
+    "jde": [],
+    "movenet": [],
+    "yolact_edge": [],
+    "yolox": [],
+    "hrnet": [],
+    "mask_rcnn": [],
+    "mtcnn": [],
+    "yolo_face": [],
+}
+
+if TYPE_CHECKING:
+    from . import (
+        csrnet,
+        efficientdet,
+        fairmot,
+        hrnet,
+        huggingface_hub,
+        jde,
+        mask_rcnn,
+        mediapipe_hub,
+        movenet,
+        mtcnn,
+        posenet,
+        yolact_edge,
+        yolo,
+        yolo_face,
+        yolo_license_plate,
+        yolox,
+    )
+else:
+    sys.modules[__name__] = _LazyModule(
+        __name__, globals()["__file__"], _import_structure, __spec__
+    )

--- a/peekingduck/pipeline/nodes/model/__init__.py
+++ b/peekingduck/pipeline/nodes/model/__init__.py
@@ -23,21 +23,21 @@ from peekingduck.utils.lazy_module import ImportStructure, _LazyModule
 
 _import_structure: ImportStructure = {
     "csrnet": [],
-    "yolo_license_plate": [],
-    "huggingface_hub": [],
-    "posenet": [],
-    "yolo": [],
-    "mediapipe_hub": [],
     "efficientdet": [],
     "fairmot": [],
-    "jde": [],
-    "movenet": [],
-    "yolact_edge": [],
-    "yolox": [],
     "hrnet": [],
+    "huggingface_hub": [],
+    "jde": [],
     "mask_rcnn": [],
+    "mediapipe_hub": [],
+    "movenet": [],
     "mtcnn": [],
+    "posenet": [],
+    "yolact_edge": [],
+    "yolo": [],
     "yolo_face": [],
+    "yolo_license_plate": [],
+    "yolox": [],
 }
 
 if TYPE_CHECKING:

--- a/peekingduck/pipeline/nodes/output/__init__.py
+++ b/peekingduck/pipeline/nodes/output/__init__.py
@@ -15,3 +15,21 @@
 """
 Writes/displays the outputs of the pipeline.
 """
+
+import sys
+from typing import TYPE_CHECKING
+
+from peekingduck.utils.lazy_module import ImportStructure, _LazyModule
+
+_import_structure: ImportStructure = {
+    "csv_writer": [],
+    "media_writer": [],
+    "screen": [],
+}
+
+if TYPE_CHECKING:
+    from . import csv_writer, media_writer, screen
+else:
+    sys.modules[__name__] = _LazyModule(
+        __name__, globals()["__file__"], _import_structure, __spec__
+    )

--- a/peekingduck/utils/lazy_module.py
+++ b/peekingduck/utils/lazy_module.py
@@ -1,0 +1,107 @@
+# Copyright 2022 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module class for lazy import to defer optional requirement checking."""
+
+import importlib
+from importlib.machinery import ModuleSpec
+from itertools import chain
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Type
+
+ImportStructure = Dict[str, List[str]]
+
+
+class _LazyModule(ModuleType):
+    """Module class that surfaces all objects but only performs associated
+    imports when the objects are requested.
+
+    Adapted from:
+    https://github.com/huggingface/transformers/blob/main/src/transformers/utils/import_utils.py#L1023
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        name: str,
+        module_file: str,
+        import_structure: ImportStructure,
+        module_spec: Optional[ModuleSpec] = None,
+        extra_objects: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(name)
+
+        self.__file__: str = module_file
+        self.__path__ = [str(Path(module_file).resolve().parent)]
+        self.__spec__ = module_spec
+        self._import_structure = import_structure
+        self._objects = {} if extra_objects is None else extra_objects
+
+        self._class_to_module = {}
+        for key, values in import_structure.items():
+            for value in values:
+                self._class_to_module[value] = key
+        # Needed for autocompletion in an IDE
+        self.__all__ = list(import_structure.keys()) + list(
+            chain(*import_structure.values())
+        )
+
+    def __dir__(self) -> Iterable[str]:
+        """Returns a list of attributes with lazy modules and classes appended.
+        Needed for autocompletion in an IDE.
+        """
+        result = super().__dir__()
+        for attr in self.__all__:
+            if attr not in result:
+                result.append(attr)  # type: ignore
+        return result
+
+    def __reduce__(
+        self,
+    ) -> Tuple[Type["_LazyModule"], Tuple[str, str, Dict[str, List[str]]]]:
+        return self.__class__, (self.__name__, self.__file__, self._import_structure)
+
+    def __getattr__(self, name: str) -> Any:
+        if name in self._objects:
+            return self._objects[name]
+        if name in self._import_structure:
+            value = self._get_module(name)
+        elif name in self._class_to_module:
+            module = self._get_module(self._class_to_module[name])
+            value = getattr(module, name)
+        else:
+            raise AttributeError(f"module {self.__name__} has no attribute {name}")
+
+        setattr(self, name, value)
+        return value
+
+    def _get_module(self, module_name: str) -> ModuleType:
+        """Imports the specified module ``module_name`` relative to this module.
+
+        Args:
+            module_name (str): The module to import.
+
+        Returns:
+            (ModuleType): The imported module ``module_name``.
+
+        Raises:
+            RuntimeError: The specified module ``module_name`` is not found.
+        """
+        try:
+            return importlib.import_module("." + module_name, self.__name__)
+        except Exception as error:
+            raise RuntimeError(
+                f"Failed to import {self.__name__}.{module_name} because of the "
+                f"following error (look up to see its traceback):\n{error}"
+            ) from error

--- a/tests/utils/test_lazy_module.py
+++ b/tests/utils/test_lazy_module.py
@@ -1,0 +1,61 @@
+# Copyright 2022 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+
+import pytest
+
+from peekingduck.declarative_loader import PEEKINGDUCK_NODE_TYPES
+from tests.conftest import PKD_DIR
+
+
+@pytest.fixture(name="node_package_and_module", params=PEEKINGDUCK_NODE_TYPES)
+def fixture_node_package_and_module(request):
+    """Returns the node package which corresponds to one of ``PEEKINGDUCK_NODE_TYPES``
+    and its corresponding node submodules.
+
+    The node package yielded (for `dabble`) is equivalent to:
+        from peekingduck.pipeline.nodes import dabble
+
+    The corresponding node submodule names yielded is:
+        ["bbox_count", "check_large_groups", ...]
+    subpackages and "__init__" are omitted.
+    """
+    package = importlib.import_module(f".{request.param}", "peekingduck.pipeline.nodes")
+
+    module_names = [
+        path.stem
+        for path in (PKD_DIR / "pipeline" / "nodes" / request.param).iterdir()
+        if path.suffix == ".py" and not path.stem.startswith("_")
+    ]
+    yield package, module_names
+
+
+def test_all_node_modules_are_surfaced(node_package_and_module):
+    """Checks that importing the <node type> subpackage and subsequently
+    instantiating node submodules works.
+
+    Equivalent to:
+        from peekingduck.pipeline.nodes import dabble
+
+        _ = dabble.bbox_count.Node()
+
+    Previously, it will fail with 'peekingduck.pipeline.nodes.dabble' has no
+    'bbox_count' error.
+    """
+    package, module_names = node_package_and_module
+
+    assert len(module_names) > 0
+    for module_name in module_names:
+        assert hasattr(package, module_name)

--- a/tests/utils/test_requirement_checker.py
+++ b/tests/utils/test_requirement_checker.py
@@ -108,7 +108,7 @@ class TestRequirementChecker:
                 captured.records,
             )
 
-    def test_checker_class_exits_the_programe_upon_update_failure(
+    def test_checker_class_exits_the_program_upon_update_failure(
         self, requirements_file
     ):
         ret_code = 123
@@ -173,8 +173,6 @@ class TestRequirementChecker:
     ):
         with mock.patch(
             "subprocess.check_output", wraps=replace_subprocess_check_output
-        ), TestCase.assertLogs(
-            "peekingduck.utils.requirement_checker.logger"
-        ) as captured:
+        ):
             # doesn't install if one of the alternative is available
             assert check_requirements(NODE_WITH_UPDATE, behavior_requirements_file) == 3


### PR DESCRIPTION
Closes https://github.com/aisingapore/PeekingDuck-Private/issues/99

- Adapt [`_LazyModule`](https://github.com/huggingface/transformers/blob/7829c890db958279ca49519cc009e4f2def3fccb/src/transformers/utils/import_utils.py#L1027) from `transformers` to enable "one-level-higher" import of PeekingDuck modules, e.g. `from peekingduck.pipeline.nodes import model`, without triggering unnecessary optional requirement installation.
- Update tutorial to recommend this way of importing PeekingDuck modules