### PR TITLE
Fix: disable code wrap in autosummary table

### DIFF
--- a/docs/source/_static/css/pkdk.css
+++ b/docs/source/_static/css/pkdk.css
@@ -41,6 +41,11 @@ dt.sig {
   white-space: normal;
 }
 
+.wy-table-responsive table.longtable td code,
+.wy-table-responsive table.longtable th code {
+  white-space: nowrap;
+}
+
 div.deprecated,
 div.versionchanged {
   margin-top: 0.5rem;


### PR DESCRIPTION
The latest changes to `sphinx-rtd-theme` (possibly issue [#289](https://sphinx-rtd-theme.readthedocs.io/en/stable/changelog.html#fixes)) have broken the [autosummary table](https://peekingduck.readthedocs.io/en/dev/nodes/model.html)

 
![image](https://user-images.githubusercontent.com/56420072/199665309-c9d724dd-174b-4648-850e-15e748cb681f.png)

**Fix**:
Set `white-space: nowrap` to the `code` elements inside the autosummary longtables to get back the original behavior.