### PR TITLE
Fix: map detect IDs in import mode

### DIFF
--- a/peekingduck/nodes/abstract_node.py
+++ b/peekingduck/nodes/abstract_node.py
@@ -29,7 +29,7 @@ from peekingduck.nodes.callback_list import CallbackList
 from peekingduck.utils.detect_id_mapper import obj_det_change_class_name_to_id
 
 
-class AbstractNode(ABC):
+class AbstractNode(ABC):  # pylint: disable=too-many-instance-attributes
     """Abstract Node class for inheritance by nodes.
 
     Defines default attributes and methods of a node.
@@ -131,12 +131,15 @@ class AbstractNode(ABC):
 
     def _change_class_name_to_id(self) -> None:
         """Convert class names to class IDs for object detection nodes, if any"""
-        if self.node_name in ["model.yolo", "model.efficientdet", "model.yolox"]:
+        if not any(key in self.config for key in ("detect", "detect_ids")):
+            return
+        if self.node_name not in {"model.yolo_face", "model.huggingface_hub"}:
             key = "detect" if hasattr(self, "detect") else "detect_ids"
             current_ids = self.config[key]
             updated_ids = obj_det_change_class_name_to_id(self.node_name, current_ids)
             # replace "detect_ids" with new "detect"
             self.config["detect"] = updated_ids
+            self.detect = updated_ids
 
     def _check_type(
         self, config: Dict[str, Any], config_types: Dict[str, Any], parent: str = ""


### PR DESCRIPTION
Closes https://github.com/aisingapore/PeekingDuck-Private/issues/112

Uses a similar "exclude unsupported models" approach in the `_change_class_name_to_id()` method in `AbstractNode`.

Note: The `_change_class_name_to_id()` method in `DeclarativeLoader` is actually not needed to ensure the pipeline runs properly both in pipeline config mode and import mode. If it is removed we will only lose the initial updated config value logging message:

Current implementation:
```
2022-12-06 15:46:06 peekingduck.declarative_loader  INFO:  Config for node model.efficientdet is updated to: 'detect': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 26, 27, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 66, 69, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 83, 84, 85, 86, 87, 88, 89]
2022-12-06 15:46:17 peekingduck.nodes.model.efficientdet_d04.efficientdet_files.detector  INFO:  EfficientDet model loaded with following configs:
        Model type: D0
        IDs being detected: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 26, 27, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 66, 69, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 83, 84, 85, 86, 87, 88, 89]
        Score threshold: 0.3
```

If removed:
```
2022-12-06 16:03:17 peekingduck.declarative_loader  INFO:  Config for node model.efficientdet is updated to: 'detect': ['*']
2022-12-06 16:03:17 peekingduck.utils.detect_id_mapper  INFO:  Detecting all object classes
2022-12-06 16:03:27 peekingduck.nodes.model.efficientdet_d04.efficientdet_files.detector  INFO:  EfficientDet model loaded with following configs:
        Model type: D0
        IDs being detected: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 26, 27, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 66, 69, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 83, 84, 85, 86, 87, 88, 89]
        Score threshold: 0.3
```

The PR currently does not remove the detect ID mapping in `DeclarativeLoader` but can be updated to include the change if losing the config updated logging message is acceptable.