### PR TITLE
Fix: nearby objs config key

### DIFF
--- a/docs/source/use_cases/group_size_checking.rst
+++ b/docs/source/use_cases/group_size_checking.rst
@@ -101,7 +101,7 @@ These are the nodes used in the earlier demo (also in |pipeline_config|_):
        focal_length: 1.14
        torso_factor: 0.9
    - dabble.group_nearby_objs:
-       obj_dist_threshold: 1.5
+       near_threshold: 1.5
    - dabble.check_large_groups:
        group_size_threshold: 2
    - draw.poses
@@ -123,7 +123,7 @@ Some common node behaviors that you might need to adjust are:
 * ``focal_length`` & ``torso_factor``: We calibrated these settings using a Logitech c170 webcam,
   with 2 individuals of heights about 1.7m. We recommend running a few experiments on your setup
   and calibrate these accordingly.
-* ``obj_dist_threshold``: The maximum distance between 2 individuals, in meters, for them to be
+* ``near_threshold``: The maximum distance between 2 individuals, in meters, for them to be
   considered to be part of a group.
 * ``group_size_threshold``: The acceptable group size limit.
 

--- a/peekingduck/configs/dabble/group_nearby_objs.yml
+++ b/peekingduck/configs/dabble/group_nearby_objs.yml
@@ -2,4 +2,4 @@ input: ["obj_3D_locs"]
 output: ["obj_attrs"]
 callbacks: {}
 
-obj_dist_threshold: 1.5
+near_threshold: 1.5

--- a/peekingduck/nodes/dabble/group_nearby_objs.py
+++ b/peekingduck/nodes/dabble/group_nearby_objs.py
@@ -39,16 +39,19 @@ class Node(AbstractNode):
         :mod:`dabble.group_nearby_objs` produces the ``groups`` attribute.
 
     Configs:
-        obj_dist_threshold (:obj:`float`): **default = 1.5**. |br|
+        near_threshold (:obj:`float`): **default = 1.5**. |br|
             Threshold of distance, in metres, between two objects. Objects with
-            distance less than ``obj_dist_threshold`` would be assigned to the
-            same group.
+            distance less than ``near_threshold`` would be considered as near
+            and assigned to the same group.
 
     .. versionchanged:: 1.2.0
         :mod:`draw.group_nearby_objs` used to return ``obj_tags``
         (:obj:`List[str]`) as an output data type, which has been deprecated
         and now subsumed under :term:`obj_attrs`. The same attribute is
         accessed by the ``groups`` key of :term:`obj_attrs`.
+
+    .. versionchanged:: 2.0.0
+        Config ``obj_dist_threshold`` has been renamed to ``near_threshold``.
     """
 
     def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:
@@ -61,7 +64,7 @@ class Node(AbstractNode):
         group. Repeat for all object pairs.
         """
         nearby_obj_pairs = self._find_nearby_obj_pairs(
-            inputs["obj_3D_locs"], self.obj_dist_threshold
+            inputs["obj_3D_locs"], self.near_threshold
         )
 
         quickfind = QuickFind(len(inputs["obj_3D_locs"]))
@@ -73,11 +76,11 @@ class Node(AbstractNode):
 
     def _get_config_types(self) -> Dict[str, Any]:
         """Returns dictionary mapping the node's config keys to respective types."""
-        return {"obj_dist_threshold": float}
+        return {"near_threshold": float}
 
     @staticmethod
     def _find_nearby_obj_pairs(
-        obj_locs: List[np.ndarray], obj_dist_threshold: float
+        obj_locs: List[np.ndarray], near_threshold: float
     ) -> List[Tuple[int, int]]:
         """If the distance between 2 objects are less than the threshold,
         append their indexes to nearby_obj_pairs as a tuple.
@@ -90,7 +93,7 @@ class Node(AbstractNode):
 
                 dist_bet = np.linalg.norm(loc_1 - loc_2)
 
-                if dist_bet <= obj_dist_threshold:
+                if dist_bet <= near_threshold:
                     if (idx_2, idx_1) not in nearby_obj_pairs:
                         nearby_obj_pairs.append((idx_1, idx_2))
 

--- a/tests/nodes/dabble/test_group_nearby_objs.py
+++ b/tests/nodes/dabble/test_group_nearby_objs.py
@@ -21,7 +21,7 @@ from peekingduck.nodes.dabble.group_nearby_objs import Node
 @pytest.fixture
 def group_nearby_objs():
     node = Node(
-        {"input": ["obj_3D_locs"], "output": ["obj_attrs"], "obj_dist_threshold": 1.5}
+        {"input": ["obj_3D_locs"], "output": ["obj_attrs"], "near_threshold": 1.5}
     )
     return node
 

--- a/tests/use_cases/systest_group_size_checking.yml
+++ b/tests/use_cases/systest_group_size_checking.yml
@@ -6,9 +6,9 @@ nodes:
     focal_length: 1.14
     torso_factor: 0.9
 - dabble.group_nearby_objs:
-    obj_dist_threshold: 1.5
+    near_threshold: 1.5
 - dabble.check_large_groups:
     group_size_threshold: 2
-- draw.bbox     # not in demo config, but included here
+- draw.bbox # not in demo config, but included here
 - draw.poses
 - draw.group_bbox_and_tag

--- a/use_cases/group_size_checking.yml
+++ b/use_cases/group_size_checking.yml
@@ -6,7 +6,7 @@ nodes:
     focal_length: 1.14
     torso_factor: 0.9
 - dabble.group_nearby_objs:
-    obj_dist_threshold: 1.5
+    near_threshold: 1.5
 - dabble.check_large_groups:
     group_size_threshold: 2
 - draw.poses


### PR DESCRIPTION
Closes https://github.com/aisingapore/PeekingDuck-Private/issues/110

- Change config key from `obj_dist_threshold` to `near_threshold` in `dabble.group_nearby_objs` for consistency.
- Update relevant docs and tests 