### PR TITLE
Fix: create ragged numpy array with dtype=object explicitly

### DIFF
--- a/peekingduck/utils/pose/keypoint_handler.py
+++ b/peekingduck/utils/pose/keypoint_handler.py
@@ -66,7 +66,8 @@ class KeypointHandler(ABC):
             [
                 [pose[edge] for edge in self.SKELETON if mask[edge].all()]
                 for pose, mask in zip(self.keypoints, self.keypoint_masks)
-            ]
+            ],
+            dtype=object,
         )
 
     @property

--- a/tests/nodes/model/hrnetv1/test_hrnet.py
+++ b/tests/nodes/model/hrnetv1/test_hrnet.py
@@ -83,7 +83,9 @@ class TestHRNet:
 
         npt.assert_allclose(output["keypoints"], expected["keypoints"], atol=TOLERANCE)
         npt.assert_allclose(
-            output["keypoint_conns"], expected["keypoint_conns"], atol=TOLERANCE
+            np.asarray(output["keypoint_conns"], dtype=float),
+            expected["keypoint_conns"],
+            atol=TOLERANCE,
         )
         npt.assert_allclose(
             output["keypoint_scores"], expected["keypoint_scores"], atol=TOLERANCE
@@ -112,7 +114,7 @@ class TestHRNet:
         # Thus, iterate through the detections
         for i, expected_keypoint_conns in enumerate(expected["keypoint_conns"]):
             npt.assert_allclose(
-                output["keypoint_conns"][i],
+                np.asarray(output["keypoint_conns"][i], dtype=float),
                 expected_keypoint_conns,
                 atol=TOLERANCE,
             )

--- a/tests/nodes/model/movenetv1/test_movenet.py
+++ b/tests/nodes/model/movenetv1/test_movenet.py
@@ -113,7 +113,9 @@ class TestMoveNet:
         npt.assert_equal(output["bbox_labels"], expected["bbox_labels"])
         npt.assert_allclose(output["keypoints"], expected["keypoints"], atol=TOLERANCE)
         npt.assert_allclose(
-            output["keypoint_conns"], expected["keypoint_conns"], atol=TOLERANCE
+            np.asarray(output["keypoint_conns"], dtype=float),
+            expected["keypoint_conns"],
+            atol=TOLERANCE,
         )
         npt.assert_allclose(
             output["keypoint_scores"], expected["keypoint_scores"], atol=TOLERANCE
@@ -141,7 +143,9 @@ class TestMoveNet:
         # Thus, iterate through the detections
         for i, expected_keypoint_conns in enumerate(expected["keypoint_conns"]):
             npt.assert_allclose(
-                output["keypoint_conns"][i], expected_keypoint_conns, atol=TOLERANCE
+                np.asarray(output["keypoint_conns"][i], dtype=float),
+                expected_keypoint_conns,
+                atol=TOLERANCE,
             )
 
         npt.assert_allclose(

--- a/tests/nodes/model/posenetv1/test_posenet.py
+++ b/tests/nodes/model/posenetv1/test_posenet.py
@@ -101,7 +101,9 @@ class TestPoseNet:
         npt.assert_equal(output["bbox_labels"], expected["bbox_labels"])
         npt.assert_allclose(output["keypoints"], expected["keypoints"], atol=TOLERANCE)
         npt.assert_allclose(
-            output["keypoint_conns"], expected["keypoint_conns"], atol=TOLERANCE
+            np.asarray(output["keypoint_conns"], dtype=float),
+            expected["keypoint_conns"],
+            atol=TOLERANCE,
         )
         npt.assert_allclose(
             output["keypoint_scores"], expected["keypoint_scores"], atol=TOLERANCE
@@ -129,7 +131,7 @@ class TestPoseNet:
         # Thus, iterate through the detections
         for i, expected_keypoint_conns in enumerate(expected["keypoint_conns"]):
             npt.assert_allclose(
-                output["keypoint_conns"][i],
+                np.asarray(output["keypoint_conns"][i], dtype=float),
                 expected_keypoint_conns,
                 atol=TOLERANCE,
             )


### PR DESCRIPTION
- Creates ragged numpy array from list of list with `dtype=object` due to [numpy deprecation](https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations) (gh-22004)
- Cast `keypoint_conns` with `dtype=float` to pass unit tests