### PR TITLE
Fix: cast connections keypoint to float

### DIFF
--- a/.github/workflows/weekly_system_test.yml
+++ b/.github/workflows/weekly_system_test.yml
@@ -1,0 +1,42 @@
+name: Weekly System Test
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * 0"
+
+jobs:
+  system-checks:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: dev
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install peekingduck locally
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            TEST_VER=0.0.0dev
+          else
+            TEST_VER=`grep -m 1 TEST_VERSION ./tests/module_import/test_module_import.py | cut -d ' ' -f 3`
+            TEST_VER=`echo ${TEST_VER} | cut -d '"' -f 2`
+          fi
+          echo "test_module_import.py TEST_VER=${TEST_VER}"
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements_cicd.txt
+          bash ./scripts/update_version.sh ${TEST_VER}
+          pip install . --no-dependencies
+        shell: bash
+      - name: Run import peekingduck as module tests
+        run: bash ./scripts/run_tests.sh module
+      - name: Run system-checks
+        uses: ./.github/actions/system-test # note only works after checkout@v2

--- a/peekingduck/nodes/draw/utils/general.py
+++ b/peekingduck/nodes/draw/utils/general.py
@@ -54,7 +54,7 @@ def project_points_onto_original_image(
     if len(points) == 0:
         return np.empty(0)
 
-    points = points.reshape((-1, 2))
+    points = points.reshape((-1, 2)).astype(float)
 
     return np.rint(points * image_size).astype(int)
 

--- a/tests/nodes/draw/test_pose.py
+++ b/tests/nodes/draw/test_pose.py
@@ -139,10 +139,8 @@ class TestPose:
 
         keypoints = np.random.rand(1, 17, 2)  # keypoints shape for 1 person
         keypoint_scores = np.random.rand(1, 17)  # keypoint_scores shape for 1 person
-        keypoint_conns = np.random.rand(
-            1, 15, 2, 2
-        )  # keypoint_conns shape for 1 person
-
+        # keypoint_conns shape for 1 person, cast to object
+        keypoint_conns = np.random.rand(1, 15, 2, 2).astype(object)
         inputs = {
             "keypoints": keypoints,
             "keypoint_scores": keypoint_scores,

--- a/tests/nodes/draw/test_pose.py
+++ b/tests/nodes/draw/test_pose.py
@@ -139,7 +139,11 @@ class TestPose:
 
         keypoints = np.random.rand(1, 17, 2)  # keypoints shape for 1 person
         keypoint_scores = np.random.rand(1, 17)  # keypoint_scores shape for 1 person
-        # keypoint_conns shape for 1 person, cast to object
+        # keypoint_conns shape for 1 person
+        # Cast to dtype=object to ensure that the mocked input keypoint_conns
+        # has the same type as the output from a pose estimation model.
+        # This ensures that we are testing conditions similar to running an
+        # actual pipeline instead of mocking a "nice" input for draw.pose.
         keypoint_conns = np.random.rand(1, 15, 2, 2).astype(object)
         inputs = {
             "keypoints": keypoints,


### PR DESCRIPTION
- Casts `keypoint_connections` to `float` in `project_points_onto_original_image` to play nice with `numpy.rint`
- In `draw.pose` tests, create `keypoint_connections` with `dtype=object`, to be consistent with pose estimation model return type
- Add "Weekly System Test" to run system tests on the `dev` branch every Sunday.