### PR TITLE
Cicd: bump workflow python version

### DIFF
--- a/.github/workflows/daily_drift_checks.yml
+++ b/.github/workflows/daily_drift_checks.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/post_merge_checks.yml
+++ b/.github/workflows/post_merge_checks.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - dev
-      - docs-v1.2
 
 jobs:
   all_tests:
@@ -19,7 +18,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
           cache: "pip"
       - name: Install dependencies
         run: |

--- a/.github/workflows/pre_merge_ci.yml
+++ b/.github/workflows/pre_merge_ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
           cache: "pip"
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Update Version Number
         run: |
           bash ./scripts/update_version.sh $VERSION
@@ -37,10 +37,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Update Version Number
         run: |
           bash ./scripts/update_version.sh $VERSION
@@ -76,10 +76,10 @@ jobs:
     needs: build-publish-test
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Test installation from PyPI
         run: |
           sleep 300

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-click == 7.1.2
+click >= 7.1.2
 colorama == 0.4.4
 huggingface_hub >= 0.9.1
-numpy >= 1.17.3
+numpy >= 1.18.5
 opencv-contrib-python >= 4.5.2.54
 protobuf <= 3.20.1
 pyyaml >= 5.3

--- a/requirements_cicd.txt
+++ b/requirements_cicd.txt
@@ -1,21 +1,20 @@
-bandit == 1.7.0
-black == 21.9b0
-coverage == 5.5
-importlib-metadata < 5; python_version < "3.8"  # fix for https://github.com/PyCQA/bandit/issues/951
-mypy == 0.910
-pylint == 2.7.4
-pytest == 6.2.3
+bandit == 1.6.0
+beautifulsoup4 == 4.11.1
+black == 22.12.0
+coverage == 7.0.5
+mypy == 0.991
+myst-parser == 0.18.1
+pylint == 2.15.10
+pytest == 7.2.0
 pytest-lazy-fixture == 0.6.3    # can remove if/when https://docs.pytest.org/en/7.1.x/proposals/parametrize_with_fixtures.html gets implemented
 scikit-image == 0.17.2
-types-PyYAML == 5.4.3
-types-requests == 2.25.0
-types-setuptools == 57.4.2
-types-six == 0.1.7
-beautifulsoup4
-myst-parser
-sphinx-autodoc-typehints
-sphinx-rtd-theme
-texttable # for pretty print scripts/check_links.py output
+sphinx-autodoc-typehints == 1.20.1
+sphinx-rtd-theme == 1.1.1
+texttable == 1.6.7  # for pretty print scripts/check_links.py output
+types-PyYAML == 6.0.12.2
+types-requests == 2.28.11.7
+types-setuptools == 65.6.0.3
+types-six == 1.16.21.4
 
 # optional requirements
 lap == 0.4.0

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 
-numpy == 1.19.5
+numpy == 1.23.5
 opencv-contrib-python >= 4.5.2.54, != 4.5.4.58, <= 4.5.5.64
 tensorflow == 2.2.0

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 
-numpy == 1.18.5
+numpy == 1.19.5
 opencv-contrib-python >= 4.5.2.54, != 4.5.4.58, <= 4.5.5.64
 tensorflow == 2.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,10 +10,9 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 classifiers =
     Development Status :: 4 - Beta
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Topic :: Scientific/Engineering :: Artificial Intelligence
@@ -21,7 +20,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.6, <3.10
+python_requires = >=3.8, <3.11
 install_requires =
     click == 7.1.2
     colorama == 0.4.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,10 +22,10 @@ classifiers =
 packages = find:
 python_requires = >=3.8, <3.11
 install_requires =
-    click == 7.1.2
+    click >= 7.1.2
     colorama == 0.4.4
     huggingface_hub >= 0.9.1
-    numpy >= 1.17.3
+    numpy >= 1.18.5
     opencv-contrib-python >= 4.5.2.54
     protobuf <= 3.20.1
     pyyaml >= 5.3


### PR DESCRIPTION
- Support Py38 - Py310
- Change CI workflows to run with Python 3.8
- Update pinned dependency versions