### PR TITLE
Test: remove cast to be compatible with numba

### DIFF
--- a/peekingduck/nodes/model/fairmotv1/fairmot_files/track.py
+++ b/peekingduck/nodes/model/fairmotv1/fairmot_files/track.py
@@ -151,8 +151,8 @@ class STrack(BaseTrack):  # pylint: disable=too-many-instance-attributes
         self.score = score
 
         self.kalman_filter: KalmanFilter
-        self.mean = np.empty((8,))
-        self.covariance = np.empty((8, 8))
+        self.mean = np.empty(0)
+        self.covariance = np.empty((0, 8))
 
         self.is_activated = False
         self.tracklet_len = 0
@@ -170,7 +170,7 @@ class STrack(BaseTrack):  # pylint: disable=too-many-instance-attributes
         """The current position in bounding box format `(top left x,
         top left y, width, height)`.
         """
-        if self.mean is None:
+        if self.mean.size == 0:
             return self._tlwh.copy()
         ret = self.mean[:4].copy()
         ret[2] *= ret[3]

--- a/peekingduck/nodes/model/posenetv1/posenet_files/jit_funcs.py
+++ b/peekingduck/nodes/model/posenetv1/posenet_files/jit_funcs.py
@@ -18,7 +18,7 @@
 PoseNet auxiliary functions (compiled with numba jit)
 """
 
-from typing import List, Tuple, cast
+from typing import List, Tuple
 
 import numpy as np
 from numba import jit_module
@@ -69,10 +69,8 @@ def is_within_nms_radius(
         radius (int): The radius/distance to check for.
         point (np.ndarray): The specified point to check.
     """
-    return cast(
-        bool,
-        existing_coords.shape[0] > 0
-        and np.any(np.sum((existing_coords - point) ** 2, axis=1) <= radius),
+    return existing_coords.shape[0] > 0 and np.any(  # type: ignore
+        np.sum((existing_coords - point) ** 2, axis=1) <= radius
     )
 
 

--- a/peekingduck/nodes/model/posenetv1/posenet_files/nojit_funcs.py
+++ b/peekingduck/nodes/model/posenetv1/posenet_files/nojit_funcs.py
@@ -18,7 +18,7 @@
 PoseNet auxiliary functions (non-compiled)
 """
 
-from typing import List, Tuple, cast
+from typing import List, Tuple
 
 import numpy as np
 
@@ -68,10 +68,8 @@ def is_within_nms_radius(
         radius (int): The radius/distance to check for.
         point (np.ndarray): The specified point to check.
     """
-    return cast(
-        bool,
-        existing_coords.shape[0] > 0
-        and np.any(np.sum((existing_coords - point) ** 2, axis=1) <= radius),
+    return existing_coords.shape[0] > 0 and np.any(  # type: ignore
+        np.sum((existing_coords - point) ** 2, axis=1) <= radius
     )
 
 


### PR DESCRIPTION
- Remove `typing.cast` to be compatible with Numba use `type: ignore` instead
- Create `mean` and `covariance` as 0-element arrays instead