### PR TITLE
Refactor: reduce test warnings

### DIFF
--- a/peekingduck/nodes/model/fairmotv1/fairmot_files/matching.py
+++ b/peekingduck/nodes/model/fairmotv1/fairmot_files/matching.py
@@ -107,11 +107,11 @@ def embedding_distance(
     Returns:
         np.ndarray: Cost matrix of distance.
     """
-    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=np.float)
+    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=float)
     if cost_matrix.size == 0:
         return cost_matrix
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     # Normalized features
     cost_matrix = np.maximum(0.0, cdist(track_features, det_features, metric))
 
@@ -161,13 +161,13 @@ def ious(xyxys_1: List[np.ndarray], xyxys_2: List[np.ndarray]) -> np.ndarray:
     Returns:
         np.ndarray: Matrix of IoU values.
     """
-    iou_values = np.zeros((len(xyxys_1), len(xyxys_2)), dtype=np.float)
+    iou_values = np.zeros((len(xyxys_1), len(xyxys_2)), dtype=float)
     if iou_values.size == 0:
         return iou_values
 
     return bbox_ious(
-        np.ascontiguousarray(xyxys_1, dtype=np.float),
-        np.ascontiguousarray(xyxys_2, dtype=np.float),
+        np.ascontiguousarray(xyxys_1, dtype=float),
+        np.ascontiguousarray(xyxys_2, dtype=float),
     )
 
 

--- a/peekingduck/nodes/model/fairmotv1/fairmot_files/track.py
+++ b/peekingduck/nodes/model/fairmotv1/fairmot_files/track.py
@@ -147,7 +147,7 @@ class STrack(BaseTrack):  # pylint: disable=too-many-instance-attributes
         feat: np.ndarray,
         buffer_size: int = 30,
     ) -> None:
-        self._tlwh = np.asarray(tlwh, dtype=np.float)
+        self._tlwh = np.asarray(tlwh, dtype=float)
         self.score = score
 
         self.kalman_filter: KalmanFilter

--- a/peekingduck/nodes/model/huggingface_hubv1/adaptors/object_detector.py
+++ b/peekingduck/nodes/model/huggingface_hubv1/adaptors/object_detector.py
@@ -54,7 +54,7 @@ class ObjectDetector(base.HuggingFaceAdaptor):
             - scores: Detections confidence score.
         """
         target_sizes = torch.tensor([target_size], device=device)
-        result = self.extractor.post_process(
+        result = self.extractor.post_process_object_detection(
             outputs=outputs, target_sizes=target_sizes
         )[0]
         return result

--- a/peekingduck/nodes/model/huggingface_hubv1/models/instance_segmentation.py
+++ b/peekingduck/nodes/model/huggingface_hubv1/models/instance_segmentation.py
@@ -132,8 +132,8 @@ class InstanceSegmentationModel(base.HuggingFaceModel):
         bboxes = xyxy2xyxyn(result["boxes"], *image_shape)
         classes = np.array([self.adaptor.id2label[int(i)] for i in result["labels"]])
         return (
-            bboxes.cpu().detach().numpy(),
+            bboxes,  # type: ignore
             classes,
-            result["scores"].cpu().detach().numpy(),
-            result["masks"].squeeze(1).cpu().detach().numpy(),
+            result["scores"],
+            result["masks"].squeeze(1),
         )

--- a/peekingduck/nodes/model/jdev1/jde_files/matching.py
+++ b/peekingduck/nodes/model/jdev1/jde_files/matching.py
@@ -108,11 +108,11 @@ def embedding_distance(
     Returns:
         np.ndarray: Cost matrix of distance.
     """
-    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=np.float)
+    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=float)
     if cost_matrix.size == 0:
         return cost_matrix
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     # Normalized features
     cost_matrix = np.maximum(0.0, cdist(track_features, det_features, metric))
 
@@ -184,13 +184,13 @@ def ious(xyxys_1: List[np.ndarray], xyxys_2: List[np.ndarray]) -> np.ndarray:
     Returns:
         np.ndarray: Matrix of IoU values.
     """
-    iou_values = np.zeros((len(xyxys_1), len(xyxys_2)), dtype=np.float)
+    iou_values = np.zeros((len(xyxys_1), len(xyxys_2)), dtype=float)
     if iou_values.size == 0:
         return iou_values
 
     return bbox_ious(
-        np.ascontiguousarray(xyxys_1, dtype=np.float),
-        np.ascontiguousarray(xyxys_2, dtype=np.float),
+        np.ascontiguousarray(xyxys_1, dtype=float),
+        np.ascontiguousarray(xyxys_2, dtype=float),
     )
 
 

--- a/peekingduck/nodes/model/jdev1/jde_files/track.py
+++ b/peekingduck/nodes/model/jdev1/jde_files/track.py
@@ -145,7 +145,7 @@ class STrack(BaseTrack):  # pylint: disable=too-many-instance-attributes
         feat: np.ndarray,
         buffer_size: int = 30,
     ) -> None:
-        self._tlwh = np.asarray(tlwh, dtype=np.float)
+        self._tlwh = np.asarray(tlwh, dtype=float)
         self.score = score
 
         self.kalman_filter: KalmanFilter

--- a/requirements_cicd.txt
+++ b/requirements_cicd.txt
@@ -7,7 +7,7 @@ myst-parser == 0.18.1
 pylint == 2.15.10
 pytest == 7.2.0
 pytest-lazy-fixture == 0.6.3    # can remove if/when https://docs.pytest.org/en/7.1.x/proposals/parametrize_with_fixtures.html gets implemented
-scikit-image == 0.17.2
+scikit-image == 0.18.0
 sphinx-autodoc-typehints == 1.20.1
 sphinx-rtd-theme == 1.1.1
 texttable == 1.6.7  # for pretty print scripts/check_links.py output

--- a/tests/nodes/draw/test_instance_mask.py
+++ b/tests/nodes/draw/test_instance_mask.py
@@ -20,7 +20,7 @@ import cv2
 import numpy as np
 import pytest
 import yaml
-from skimage.measure import compare_ssim as ssim
+from skimage.metrics import structural_similarity as ssim
 
 from peekingduck.nodes.draw.instance_mask import Node
 from tests.conftest import PKD_DIR, TEST_DATA_DIR, TEST_IMAGES_DIR

--- a/tests/utils/bbox/test_bbox_transforms.py
+++ b/tests/utils/bbox/test_bbox_transforms.py
@@ -161,7 +161,9 @@ class TestBboxTransforms:
         expected_bbox = expand_dim(convert_type(expected_bbox), num_dims)
 
         if isinstance(to_bbox, torch.Tensor):
-            torch.testing.assert_allclose(to_bbox, expected_bbox, atol=ATOL, rtol=RTOL)
+            torch.testing.assert_close(
+                to_bbox, expected_bbox, atol=ATOL, rtol=RTOL, check_dtype=False
+            )
         else:
             npt.assert_allclose(to_bbox, expected_bbox, atol=ATOL, rtol=RTOL)
 
@@ -179,6 +181,8 @@ class TestBboxTransforms:
         expected_bbox = expand_dim(convert_type(expected_bbox), num_dims)
 
         if isinstance(to_bbox, torch.Tensor):
-            torch.testing.assert_allclose(to_bbox, expected_bbox, atol=ATOL, rtol=RTOL)
+            torch.testing.assert_close(
+                to_bbox, expected_bbox, atol=ATOL, rtol=RTOL, check_dtype=False
+            )
         else:
             npt.assert_allclose(to_bbox, expected_bbox, atol=ATOL, rtol=RTOL)


### PR DESCRIPTION
Addresses https://github.com/aisingapore/PeekingDuck-Private/issues/113

- use `float` instead of `np.float`
- use `torch.testing.assert_close` instead of `torch.testing.assert_allclose`
- bump `sckit-image==0.18.0` and use `skimage.metrics.structural_similarity`
- use `post_process_object_detection` instead of `post_process` in `huggingface_hub`